### PR TITLE
feat: Add FSRS parameter tools and resource

### DIFF
--- a/anki_mcp_server/primitives/essential/resources/fsrs_config_resource.py
+++ b/anki_mcp_server/primitives/essential/resources/fsrs_config_resource.py
@@ -1,0 +1,48 @@
+"""FSRS config resource."""
+from typing import Any
+
+from ....resource_decorator import Resource
+from ....handler_wrappers import get_col
+from ..tools._fsrs_helpers import (
+    detect_fsrs_version,
+    get_fsrs_params_from_config,
+    get_presets_with_decks,
+)
+
+
+@Resource(
+    "anki://fsrs/config",
+    "FSRS configuration summary: enabled status, version, preset count, and parameter overview. "
+    "Useful for quickly checking FSRS state without a full tool call.",
+    name="fsrs_config",
+    title="FSRS Configuration",
+)
+def fsrs_config() -> dict[str, Any]:
+    col = get_col()
+
+    fsrs_enabled = col.get_config("fsrs", False)
+    fsrs_version = detect_fsrs_version()
+
+    presets_with_decks = get_presets_with_decks(col)
+
+    preset_summaries = []
+    for entry in presets_with_decks:
+        config = entry["config"]
+        decks = entry["decks"]
+        param_version, weights = get_fsrs_params_from_config(config)
+
+        preset_summaries.append({
+            "name": config["name"],
+            "has_weights": len(weights) > 0,
+            "param_count": len(weights),
+            "param_version": param_version,
+            "desired_retention": config.get("desiredRetention", 0.9),
+            "deck_count": len(decks),
+        })
+
+    return {
+        "fsrs_enabled": fsrs_enabled,
+        "fsrs_version": fsrs_version,
+        "total_presets": len(preset_summaries),
+        "presets": preset_summaries,
+    }

--- a/anki_mcp_server/primitives/essential/tools/_fsrs_helpers.py
+++ b/anki_mcp_server/primitives/essential/tools/_fsrs_helpers.py
@@ -1,0 +1,89 @@
+"""FSRS helper utilities used by FSRS tools."""
+from typing import Any
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+MIN_FSRS_VERSION = 4
+
+
+def detect_fsrs_version() -> int | None:
+    """Detect the highest FSRS version supported by the current Anki build."""
+    try:
+        from anki import deck_config_pb2
+        field_names = set(
+            deck_config_pb2.DeckConfig.Config.DESCRIPTOR.fields_by_name.keys()
+        )
+        return max(
+            (
+                int(m.group(1))
+                for name in field_names
+                if (m := re.search(r"fsrs_params_(\d+)", name))
+            ),
+            default=None,
+        )
+    except Exception:
+        logger.debug("Could not detect FSRS version via protobuf", exc_info=True)
+        return None
+
+
+def get_fsrs_params_from_config(config: dict) -> tuple[int | None, list[float]]:
+    """Read FSRS weights from a deck config dict, trying versioned keys with fallback."""
+    fsrs_version = detect_fsrs_version()
+    max_version = fsrs_version if fsrs_version is not None else 6
+
+    for version in range(max_version, MIN_FSRS_VERSION - 1, -1):
+        params = config.get(f"fsrsParams{version}")
+        if params and len(params) > 0:
+            return version, list(params)
+
+    legacy = config.get("fsrsWeights")
+    if legacy and len(legacy) > 0:
+        return None, list(legacy)
+
+    return None, []
+
+
+def find_preset_by_name(col: Any, name: str) -> dict | None:
+    for conf in col.decks.all_config():
+        if conf["name"].lower() == name.lower():
+            return conf
+    return None
+
+
+def get_desired_retention(col: Any, did: int) -> float:
+    # Per-deck overrides are stored as a percentage (0-100)
+    deck = col.decks.get(did)
+    if deck is not None:
+        per_deck = deck.get("desiredRetention")
+        if per_deck is not None:
+            return per_deck / 100.0
+
+    config = col.decks.config_dict_for_deck_id(did)
+    return config.get("desiredRetention", 0.9)
+
+
+def get_presets_with_decks(col: Any) -> list[dict[str, Any]]:
+    """Map each deck config preset to its associated decks."""
+    all_configs = col.decks.all_config()
+    all_decks = col.decks.all_names_and_ids()
+
+    config_map = {conf["id"]: conf for conf in all_configs}
+    config_decks = {cid: [] for cid in config_map}
+
+    for deck_pair in all_decks:
+        did = deck_pair.id
+        deck_name = deck_pair.name
+        try:
+            deck_conf = col.decks.config_dict_for_deck_id(did)
+            cid = deck_conf["id"]
+            if cid in config_decks:
+                config_decks[cid].append({"name": deck_name, "id": did})
+        except Exception:
+            logger.debug("Could not get config for deck %s", deck_name, exc_info=True)
+
+    return [
+        {"config": conf, "decks": config_decks.get(cid, [])}
+        for cid, conf in config_map.items()
+    ]

--- a/anki_mcp_server/primitives/essential/tools/get_card_memory_state_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/get_card_memory_state_tool.py
@@ -1,0 +1,120 @@
+"""Get card memory state tool - read FSRS memory state for individual cards."""
+from typing import Any
+import logging
+import time
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_NAMES = {
+    -1: "suspended",
+    -2: "sibling_buried",
+    -3: "manually_buried",
+    0: "new",
+    1: "learning",
+    2: "review",
+    3: "day_learning",
+    4: "preview",
+}
+
+_TYPE_NAMES = {
+    0: "new",
+    1: "learning",
+    2: "review",
+    3: "relearning",
+}
+
+
+@Tool(
+    "get_card_memory_state",
+    "Get FSRS memory state (stability, difficulty, retrievability) for one or more cards. "
+    "Requires FSRS to be enabled. Returns per-card memory state along with scheduling info. "
+    "Use recompute=True to recalculate from the review log (slower but ensures accuracy).",
+)
+def get_card_memory_state(card_ids: list[int], recompute: bool = False) -> dict[str, Any]:
+    col = get_col()
+
+    if not card_ids:
+        raise HandlerError(
+            "No card IDs provided",
+            hint="Provide at least one card ID. Use findNotes or card_management to find card IDs.",
+        )
+
+    fsrs_enabled = col.get_config("fsrs", False)
+    if not fsrs_enabled:
+        raise HandlerError(
+            "FSRS is not enabled",
+            hint="Enable FSRS in Anki's deck options before using this tool.",
+        )
+
+    cards = []
+    not_found = []
+
+    for cid in card_ids:
+        try:
+            card = col.get_card(cid)
+        except Exception:
+            not_found.append(cid)
+            continue
+
+        card_info = _extract_card_state(col, card, recompute)
+        cards.append(card_info)
+
+    result = {
+        "cards": cards,
+        "total": len(cards),
+    }
+
+    if not_found:
+        result["not_found"] = not_found
+
+    return result
+
+
+def _extract_card_state(col: Any, card: Any, recompute: bool) -> dict[str, Any]:
+    cid = card.id
+
+    info = {
+        "card_id": cid,
+        "interval": card.ivl,
+        "due": card.due,
+        "queue": _QUEUE_NAMES.get(card.queue, f"unknown({card.queue})"),
+        "type": _TYPE_NAMES.get(card.type, f"unknown({card.type})"),
+        "reps": card.reps,
+        "lapses": card.lapses,
+    }
+
+    memory_state = None
+    if recompute:
+        try:
+            memory_state = col.compute_memory_state(cid)
+        except AttributeError:
+            logger.debug("col.compute_memory_state not available, falling back to card.memory_state")
+            memory_state = getattr(card, "memory_state", None)
+        except Exception:
+            logger.debug("Failed to compute memory state for card %d", cid, exc_info=True)
+            memory_state = getattr(card, "memory_state", None)
+    else:
+        memory_state = getattr(card, "memory_state", None)
+
+    if memory_state is not None:
+        info["stability"] = getattr(memory_state, "stability", None)
+        info["difficulty"] = getattr(memory_state, "difficulty", None)
+
+        stability = info.get("stability")
+        if stability and stability > 0 and card.ivl > 0 and card.type == 2:
+            today = int(time.time() - card.col.crt) // 86400
+            elapsed_days = today - (card.due - card.ivl)
+            info["elapsed_days"] = elapsed_days
+            if elapsed_days >= 0:
+                # FSRS-5+ power-forgetting curve: R = (1 + elapsed/9S)^-1
+                info["retrievability"] = round(
+                    (1 + elapsed_days / (9 * stability)) ** (-1), 4
+                )
+    else:
+        info["stability"] = None
+        info["difficulty"] = None
+
+    return info

--- a/anki_mcp_server/primitives/essential/tools/get_fsrs_params_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/get_fsrs_params_tool.py
@@ -1,0 +1,121 @@
+"""Get FSRS params tool - read FSRS parameters for all presets or a specific deck."""
+from typing import Any
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+from ._fsrs_helpers import (
+    detect_fsrs_version,
+    get_fsrs_params_from_config,
+    get_desired_retention,
+    get_presets_with_decks,
+)
+
+
+@Tool(
+    "get_fsrs_params",
+    "Get FSRS scheduler parameters for Anki deck presets. "
+    "Returns FSRS weights, desired retention, max interval, and other settings. "
+    "If deck_name is empty, returns parameters for all presets with their associated decks. "
+    "If deck_name is provided, returns parameters for the preset used by that deck.",
+)
+def get_fsrs_params(deck_name: str = "") -> dict[str, Any]:
+    col = get_col()
+
+    fsrs_enabled = col.get_config("fsrs", False)
+    fsrs_version = detect_fsrs_version()
+
+    if deck_name:
+        return _get_params_for_deck(col, deck_name, fsrs_enabled, fsrs_version)
+    else:
+        return _get_all_params(col, fsrs_enabled, fsrs_version)
+
+
+def _format_preset(
+    config: dict,
+    decks: list[dict[str, Any]],
+    col: Any,
+    fsrs_version: int | None,
+) -> dict[str, Any]:
+    param_version, weights = get_fsrs_params_from_config(config)
+
+    desired_retention = config.get("desiredRetention", 0.9)
+    if decks:
+        desired_retention = get_desired_retention(col, decks[0]["id"])
+
+    result = {
+        "preset_name": config["name"],
+        "preset_id": config["id"],
+        "fsrs_weights": weights,
+        "fsrs_param_version": param_version,
+        "desired_retention": desired_retention,
+        "max_interval": config.get("maxIvl", 36500),
+        "decks": [d["name"] for d in decks],
+    }
+
+    param_search = config.get("paramSearch") or config.get("weightSearch")
+    if param_search:
+        result["param_search"] = param_search
+
+    ignore_before = config.get("ignoreRevlogsBeforeDate")
+    if ignore_before:
+        result["ignore_revlogs_before_date"] = ignore_before
+
+    easy_days = config.get("easyDaysPercentages")
+    if easy_days:
+        result["easy_days_percentages"] = easy_days
+
+    return result
+
+
+def _get_params_for_deck(
+    col: Any, deck_name: str, fsrs_enabled: bool, fsrs_version: int | None
+) -> dict[str, Any]:
+    all_decks = col.decks.all_names_and_ids()
+    target_deck = None
+    for d in all_decks:
+        if d.name.lower() == deck_name.lower():
+            target_deck = d
+            break
+
+    if target_deck is None:
+        raise HandlerError(
+            f"Deck not found: {deck_name}",
+            hint="Check spelling or use list_decks to see available decks",
+        )
+
+    config = col.decks.config_dict_for_deck_id(target_deck.id)
+
+    all_configs_with_decks = get_presets_with_decks(col)
+    decks_using_preset = []
+    for entry in all_configs_with_decks:
+        if entry["config"]["id"] == config["id"]:
+            decks_using_preset = entry["decks"]
+            break
+
+    preset_info = _format_preset(config, decks_using_preset, col, fsrs_version)
+
+    return {
+        "fsrs_enabled": fsrs_enabled,
+        "fsrs_version": fsrs_version,
+        "deck_name": deck_name,
+        "preset": preset_info,
+    }
+
+
+def _get_all_params(
+    col: Any, fsrs_enabled: bool, fsrs_version: int | None
+) -> dict[str, Any]:
+    presets_with_decks = get_presets_with_decks(col)
+
+    presets = []
+    for entry in presets_with_decks:
+        config = entry["config"]
+        decks = entry["decks"]
+        presets.append(_format_preset(config, decks, col, fsrs_version))
+
+    return {
+        "fsrs_enabled": fsrs_enabled,
+        "fsrs_version": fsrs_version,
+        "presets": presets,
+        "total_presets": len(presets),
+    }

--- a/anki_mcp_server/primitives/essential/tools/optimize_fsrs_params_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/optimize_fsrs_params_tool.py
@@ -1,0 +1,148 @@
+"""Optimize FSRS params tool - run FSRS parameter optimization via Anki backend."""
+from typing import Any
+from datetime import datetime, timezone
+import math
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+from ._fsrs_helpers import (
+    detect_fsrs_version,
+    find_preset_by_name,
+    get_fsrs_params_from_config,
+)
+
+
+def _get_anki_point_version() -> int:
+    try:
+        from anki.utils import point_version
+        return point_version()
+    except ImportError:
+        try:
+            from anki.buildinfo import version
+            parts = version.split(".")
+            if len(parts) >= 2:
+                return int(parts[0]) * 10000 + int(parts[1]) * 100
+        except Exception:
+            pass
+    return 0
+
+
+def _get_relearning_steps_in_day(deck_config: dict) -> int:
+    # Ported from Anki TS: FsrsOptions.svelte
+    num_steps = 0
+    accumulated_time = 0
+    for step in deck_config.get("lapse", {}).get("delays", []):
+        accumulated_time += step
+        if accumulated_time >= 24 * 60:
+            break
+        num_steps += 1
+    return num_steps
+
+
+def _fsrs_params_equal(params1: list[float], params2: list[float]) -> bool:
+    if len(params1) != len(params2):
+        return False
+    return all(
+        math.isclose(a, b, abs_tol=6e-5, rel_tol=0.0)
+        for a, b in zip(params1, params2)
+    )
+
+
+@Tool(
+    "optimize_fsrs_params",
+    "Run FSRS parameter optimization for a deck config preset using Anki's built-in optimizer. "
+    "This analyzes review history to find optimal FSRS weights. "
+    "Set apply_results=False (default) for a dry run that shows what the optimized params would be. "
+    "Set apply_results=True to save the optimized parameters. "
+    "This operation runs synchronously and typically takes 5-30 seconds depending on review history size.",
+    write=True,
+)
+def optimize_fsrs_params(preset_name: str, apply_results: bool = False) -> dict[str, Any]:
+    col = get_col()
+
+    config = find_preset_by_name(col, preset_name)
+    if config is None:
+        all_configs = col.decks.all_config()
+        available = [c["name"] for c in all_configs]
+        raise HandlerError(
+            f"Preset not found: {preset_name}",
+            hint=f"Available presets: {', '.join(available)}",
+        )
+
+    fsrs_enabled = col.get_config("fsrs", False)
+    if not fsrs_enabled:
+        raise HandlerError(
+            "FSRS is not enabled",
+            hint="Enable FSRS in Anki's deck options before optimizing parameters.",
+        )
+
+    current_version, current_params = get_fsrs_params_from_config(config)
+
+    config_name_escaped = config["name"].replace("\\", "\\\\").replace('"', '\\"')
+    search = config.get("paramSearch") or config.get("weightSearch") or f'preset:"{config_name_escaped}" -is:suspended'
+
+    ignore_before_str = config.get("ignoreRevlogsBeforeDate") or "1970-01-01"
+    try:
+        ignore_before_date = datetime.fromisoformat(ignore_before_str).replace(tzinfo=timezone.utc)
+        ignore_before_ms = int(ignore_before_date.timestamp() * 1000)
+    except ValueError:
+        ignore_before_ms = 0
+
+    anki_version = _get_anki_point_version()
+    extra_kwargs = {}
+
+    if anki_version >= 250200:
+        extra_kwargs["num_of_relearning_steps"] = _get_relearning_steps_in_day(config)
+
+    if anki_version >= 250700:
+        extra_kwargs["health_check"] = False
+
+    try:
+        from anki import scheduler_pb2  # noqa: F401
+        response = col.backend.compute_fsrs_params(
+            search=search,
+            current_params=current_params,
+            ignore_revlogs_before_ms=ignore_before_ms,
+            **extra_kwargs,
+        )
+    except Exception as e:
+        raise HandlerError(
+            f"FSRS optimization failed: {e}",
+            hint="Ensure the preset has enough review history. At least 400 reviews are recommended.",
+        )
+
+    optimized_params = list(response.params)
+    fsrs_items = getattr(response, "fsrs_items", None)
+
+    already_optimal = not optimized_params or _fsrs_params_equal(current_params, optimized_params)
+
+    result = {
+        "preset_name": preset_name,
+        "preset_id": config["id"],
+        "current_params": current_params,
+        "optimized_params": optimized_params,
+        "already_optimal": already_optimal,
+        "search_query": search,
+    }
+
+    if fsrs_items is not None:
+        result["fsrs_items"] = fsrs_items
+
+    if apply_results and not already_optimal and optimized_params:
+        fsrs_version = detect_fsrs_version()
+        param_key = f"fsrsParams{fsrs_version}" if fsrs_version else "fsrsParams6"
+
+        config = col.decks.get_config(config["id"])
+        config[param_key] = optimized_params
+        col.decks.update_config(config)
+
+        result["applied"] = True
+        result["param_key"] = param_key
+    else:
+        result["applied"] = False
+        if already_optimal:
+            result["message"] = "Parameters are already optimal."
+        elif not apply_results:
+            result["message"] = "Dry run complete. Set apply_results=True to save."
+
+    return result

--- a/anki_mcp_server/primitives/essential/tools/set_fsrs_params_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/set_fsrs_params_tool.py
@@ -1,0 +1,109 @@
+"""Set FSRS params tool - update FSRS parameters on a deck config preset."""
+from typing import Any
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+from ._fsrs_helpers import (
+    detect_fsrs_version,
+    find_preset_by_name,
+    get_fsrs_params_from_config,
+)
+
+_EXPECTED_PARAM_COUNTS = {
+    5: 19,
+    6: 19,
+}
+
+
+@Tool(
+    "set_fsrs_params",
+    "Update FSRS parameters on a deck config preset. "
+    "Can set FSRS weights, desired retention (0.70-0.99), and/or max interval. "
+    "At least one parameter must be changed. Returns old/new diff for each changed field. "
+    "Use get_fsrs_params first to see current values.",
+    write=True,
+)
+def set_fsrs_params(
+    preset_name: str,
+    fsrs_params: list[float] = [],
+    desired_retention: float = -1.0,
+    max_interval: int = -1,
+) -> dict[str, Any]:
+    col = get_col()
+
+    config = find_preset_by_name(col, preset_name)
+    if config is None:
+        all_configs = col.decks.all_config()
+        available = [c["name"] for c in all_configs]
+        raise HandlerError(
+            f"Preset not found: {preset_name}",
+            hint=f"Available presets: {', '.join(available)}",
+        )
+
+    has_params = len(fsrs_params) > 0
+    has_retention = desired_retention >= 0
+    has_max_interval = max_interval >= 0
+
+    if not has_params and not has_retention and not has_max_interval:
+        raise HandlerError(
+            "No changes specified",
+            hint="Provide at least one of: fsrs_params, desired_retention, max_interval",
+        )
+
+    changes = {}
+
+    if has_params:
+        fsrs_version = detect_fsrs_version()
+        expected_count = _EXPECTED_PARAM_COUNTS.get(fsrs_version, 19) if fsrs_version else 19
+
+        if len(fsrs_params) != expected_count:
+            raise HandlerError(
+                f"Invalid parameter count: got {len(fsrs_params)}, expected {expected_count} for FSRS v{fsrs_version}",
+                hint=f"FSRS v{fsrs_version} requires exactly {expected_count} parameters.",
+            )
+
+        _, old_params = get_fsrs_params_from_config(config)
+        param_key = f"fsrsParams{fsrs_version}" if fsrs_version else "fsrsParams6"
+        config[param_key] = fsrs_params
+        changes["fsrs_params"] = {
+            "old": old_params,
+            "new": list(fsrs_params),
+            "key": param_key,
+        }
+
+    if has_retention:
+        if not (0.70 <= desired_retention <= 0.99):
+            raise HandlerError(
+                f"Invalid desired retention: {desired_retention}",
+                hint="Desired retention must be between 0.70 and 0.99.",
+            )
+
+        old_retention = config.get("desiredRetention", 0.9)
+        config["desiredRetention"] = desired_retention
+        changes["desired_retention"] = {
+            "old": old_retention,
+            "new": desired_retention,
+        }
+
+    if has_max_interval:
+        if max_interval < 1:
+            raise HandlerError(
+                f"Invalid max interval: {max_interval}",
+                hint="Max interval must be at least 1 day.",
+            )
+
+        old_max_ivl = config.get("maxIvl", 36500)
+        config["maxIvl"] = max_interval
+        changes["max_interval"] = {
+            "old": old_max_ivl,
+            "new": max_interval,
+        }
+
+    col.decks.update_config(config)
+
+    return {
+        "preset_name": preset_name,
+        "preset_id": config["id"],
+        "changes": changes,
+        "status": "updated",
+    }


### PR DESCRIPTION
## Summary

- **4 new tools**: `get_fsrs_params`, `get_card_memory_state`, `set_fsrs_params`, `optimize_fsrs_params`
- **1 new resource**: `anki://fsrs/config`
- Shared helpers in `_fsrs_helpers.py` (version detection, config reading, preset lookup)

### Tools

| Tool | Description |
|------|-------------|
| `get_fsrs_params` | Read FSRS weights, desired retention, max interval for all presets or a specific deck |
| `get_card_memory_state` | Read per-card FSRS memory state (stability, difficulty, retrievability) |
| `set_fsrs_params` | Update FSRS weights, desired retention, and/or max interval on a preset |
| `optimize_fsrs_params` | Run Anki's built-in FSRS optimizer with dry-run support |

### Implementation notes

- Version-aware: detects FSRS version via protobuf field names, falls back through `fsrsParams6` → `fsrsParams5` → `fsrsParams4` → `fsrsWeights`
- Anki version compat: `optimize_fsrs_params` adapts `compute_fsrs_params` kwargs based on Anki point version (25.02+ and 25.07+)
- Per-deck desired retention overrides are resolved correctly (stored as 0-100 on deck dict vs 0-1 on preset)

## Test plan

- [x] `get_fsrs_params` (no args) — lists all presets with weights and deck mappings
- [x] `get_fsrs_params` (with deck name) — returns preset for that deck
- [x] `get_card_memory_state` (with card ID) — returns stability/difficulty/retrievability
- [x] `anki://fsrs/config` resource — shows FSRS overview
- [x] `optimize_fsrs_params` (dry run) — returns optimized weights without applying
- [x] `set_fsrs_params` — updates retention, verified in Anki UI
- [x] Built `.ankiaddon`, installed in Anki, restarted, all tools functional