### PR TITLE
fix: Support NixOS and source-based installs (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,73 @@ On first run, this addon downloads `pydantic_core` (~2MB) from PyPI. This is req
 2. Double-click to install, or use *Tools → Add-ons → Install from file...*
 3. Restart Anki
 
+### NixOS
+
+#### With flakes (recommended)
+
+Add the flake input and use the pre-built package:
+
+```nix
+# flake.nix
+{
+  inputs.anki-mcp.url = "github:ankimcp/anki-mcp-server-addon";
+
+  outputs = { nixpkgs, anki-mcp, ... }: {
+    # Option A: Standalone — Anki with the addon pre-installed
+    environment.systemPackages = [
+      anki-mcp.packages.${system}.default
+    ];
+
+    # Option B: Composable with other addons via overlay
+    nixpkgs.overlays = [ anki-mcp.overlays.default ];
+    environment.systemPackages = [
+      (pkgs.anki.withAddons [ pkgs.ankiAddons.anki-mcp-server ])
+    ];
+  };
+}
+```
+
+#### Without flakes
+
+```nix
+# configuration.nix
+{ pkgs, ... }:
+let
+  python3 = pkgs.python3;
+
+  ankiMcpPythonDeps = python3.withPackages (ps: with ps; [
+    mcp pydantic pydantic-settings starlette uvicorn anyio httpx websockets
+  ]);
+
+  anki-mcp-server = pkgs.anki-utils.buildAnkiAddon (finalAttrs: {
+    pname = "anki-mcp-server";
+    version = "0.12.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "ankimcp";
+      repo = "anki-mcp-server-addon";
+      rev = "v${finalAttrs.version}";
+      hash = ""; # nix will tell you the correct hash on first build
+    };
+    sourceRoot = "${finalAttrs.src.name}/anki_mcp_server";
+  });
+
+  ankiWithMcp = pkgs.anki.withAddons [ anki-mcp-server ];
+
+  ankiWrapped = pkgs.symlinkJoin {
+    name = "anki-with-mcp";
+    paths = [ ankiWithMcp ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/anki \
+        --prefix PYTHONPATH ':' "${ankiMcpPythonDeps}/${python3.sitePackages}"
+    '';
+  };
+in
+{
+  environment.systemPackages = [ ankiWrapped ];
+}
+```
+
 ## Usage
 
 The server starts automatically when you open Anki. Check status via *Tools → AnkiMCP Server Settings...*

--- a/anki_mcp_server/__init__.py
+++ b/anki_mcp_server/__init__.py
@@ -19,12 +19,34 @@ from pathlib import Path
 
 __version__ = "0.12.0"
 
-# Packages we vendor that might conflict with other addons
+# Packages we vendor — used for conflict detection AND system-package fallback checks
 _VENDOR_PACKAGES = ['mcp', 'pydantic', 'pydantic_core', 'starlette', 'uvicorn', 'anyio', 'httpx', 'websockets']
+
+# Set to True when running from source with system-provided packages (e.g. Nix)
+_USING_SYSTEM_PACKAGES = False
+
+
+def _check_system_packages(packages: list[str]) -> list[str]:
+    """Check which packages from the list are NOT importable from the system.
+
+    Returns a list of package names that failed to import.
+    Note: Packages that import successfully will remain in sys.modules.
+    """
+    import importlib
+    missing = []
+    for pkg in packages:
+        try:
+            importlib.import_module(pkg)
+        except ImportError:
+            missing.append(pkg)
+    return missing
 
 
 def _check_vendor_conflicts() -> list[str]:
     """Check if any vendored packages are already loaded (potential conflicts)."""
+    if _USING_SYSTEM_PACKAGES:
+        return []
+
     conflicts = []
     for pkg in _VENDOR_PACKAGES:
         if pkg in sys.modules:
@@ -34,11 +56,27 @@ def _check_vendor_conflicts() -> list[str]:
 
 def _setup_vendor_path() -> None:
     """Add shared vendor directory to sys.path."""
+    global _USING_SYSTEM_PACKAGES
+
     vendor_dir = Path(__file__).parent / "vendor"
 
     if not vendor_dir.exists():
-        print("AnkiMCP Server Warning: vendor directory not found. Dependencies may be missing.")
-        return
+        # No vendor directory — check if system provides the packages (e.g. Nix, pip from source)
+        missing = _check_system_packages(_VENDOR_PACKAGES)
+        if not missing:
+            _USING_SYSTEM_PACKAGES = True
+            print("AnkiMCP Server: vendor/ not found — using system-provided packages")
+            return
+
+        print(
+            f"AnkiMCP Server Error: vendor/ directory not found and system is missing "
+            f"required packages: {', '.join(missing)}\n"
+            f"If you installed from source, install dependencies with:\n"
+            f"  pip install {' '.join(missing)}\n"
+            f"Or download the .ankiaddon release from "
+            f"https://github.com/ankimcp/anki-mcp-server-addon/releases"
+        )
+        raise ImportError("AnkiMCP Server: required packages not available")
 
     # Check for conflicts before adding to path
     conflicts = _check_vendor_conflicts()

--- a/anki_mcp_server/dependency_loader.py
+++ b/anki_mcp_server/dependency_loader.py
@@ -99,7 +99,26 @@ def ensure_pydantic_core() -> bool:
     Returns True if pydantic_core is ready, False if failed.
     Shows progress dialog during download.
     """
-    required_version = _get_required_pydantic_core_version()
+    # Fast path: already importable (system-installed, cached, or vendored).
+    # No version check here — pydantic validates pydantic_core compatibility
+    # at its own import time and raises PydanticUserError on mismatch.
+    try:
+        import pydantic_core  # noqa: F401
+        return True
+    except ImportError:
+        pass
+
+    try:
+        required_version = _get_required_pydantic_core_version()
+    except Exception as e:
+        QMessageBox.critical(
+            None,
+            "AnkiMCP Server - Setup Failed",
+            f"Failed to determine required pydantic_core version:\n\n{e}\n\n"
+            "If you installed from source, install pydantic_core with pip.",
+        )
+        return False
+
     pypi_url = f"https://pypi.org/pypi/pydantic-core/{required_version}/json"
 
     cache_dir = CACHE_DIR / "pydantic_core_pkg"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+# Nix flake for anki-mcp-server — MCP server addon for Anki.
+# Usage:
+#   nix run .#           — launch Anki with the addon pre-installed
+#   nix build .#addon    — build just the addon package
+#
+# NixOS / home-manager users can use the overlay:
+#   pkgs.ankiAddons.anki-mcp-server
+{
+  description = "Anki addon that runs an MCP server, exposing collection operations to AI assistants";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          pythonDeps = pkgs.python3.withPackages (
+            ps: with ps; [
+              mcp
+              pydantic
+              pydantic-settings
+              starlette
+              uvicorn
+              anyio
+              httpx
+              websockets
+            ]
+          );
+
+          addon = pkgs.anki-utils.buildAnkiAddon {
+            pname = "anki-mcp-server";
+            version = "0.12.0";
+            src = ./anki_mcp_server;
+
+            postFixup = ''
+              local addonDir="$out/share/anki/addons/anki-mcp-server"
+
+              # Replace bundled vendor directory with symlinks to Nix-provided packages
+              rm -rf "$addonDir/vendor/shared"
+              mkdir -p "$addonDir/vendor/shared"
+              for entry in ${pythonDeps}/${pkgs.python3.sitePackages}/*; do
+                ln -s "$entry" "$addonDir/vendor/shared/"
+              done
+
+              # Clean up build cache if present
+              rm -rf "$addonDir/_cache"
+            '';
+
+            meta = {
+              description = "MCP server addon for Anki — expose collection operations to AI assistants";
+              homepage = "https://github.com/ankimcp/anki-mcp-server-addon";
+              license = pkgs.lib.licenses.agpl3Plus;
+            };
+          };
+        in
+        {
+          inherit addon;
+          default = pkgs.anki.withAddons [ addon ];
+        }
+      );
+
+      overlays.default = _final: prev: {
+        ankiAddons = (prev.ankiAddons or { }) // {
+          anki-mcp-server = self.packages.${prev.stdenv.hostPlatform.system}.addon;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- When `vendor/` is missing (source installs), the addon now detects system-provided packages and uses them instead of crashing
- Ships a `flake.nix` for one-line NixOS installs via `anki-mcp.packages.${system}.default`
- Fixes a side bug where a corrupted vendor file produced an ugly traceback instead of a friendly error dialog

## Changes

### `anki_mcp_server/__init__.py`
- Added `_check_system_packages()` — probes which packages are importable from the system
- `_setup_vendor_path()` now falls back to system packages when `vendor/` is missing, or raises `ImportError` with a clear message listing missing packages
- `_check_vendor_conflicts()` skipped when using system packages (no false warnings)

### `anki_mcp_server/dependency_loader.py`
- Early return in `ensure_pydantic_core()` — if `pydantic_core` is already importable (system/cached/vendored), skip the entire download flow
- Side bug fix: `_get_required_pydantic_core_version()` call moved inside `try/except` — previously an uncaught `RuntimeError` would produce a raw traceback for all users

### `flake.nix`
- Nix flake that builds the addon with `buildAnkiAddon` and symlinks nixpkgs Python packages into `vendor/shared/`
- Exports `packages.${system}.default` (Anki + addon) and an overlay for composability

### `README.md`
- Added NixOS installation section with flake and non-flake options

## Test plan

- [x] Reproduced the original crash on NixOS VM (Parallels, aarch64, NixOS 25.11)
- [x] Validated fix with system packages (PYTHONPATH approach)
- [x] Validated flake.nix (`nix run` and `flake.nix` in NixOS config)
- [x] E2E tests pass (backward compatibility with `.ankiaddon` installs)
- [x] Manual sanity tests via MCP tools (list_decks, find_notes, notes_info, tag_management)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)