### PR TITLE
fix: Media path traversal & SSRF prevention (v0.14.0)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload .ankiaddon artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: anki_mcp_server.ankiaddon
           path: anki_mcp_server.ankiaddon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
@@ -61,10 +61,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -72,7 +72,7 @@ jobs:
         run: ./package.sh
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: '*.ankiaddon'
           generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,18 @@ raise HandlerError(
 
 ## Key Implementation Details
 
+### Versioning & Releases
+
+Version lives in `__init__.py:__version__`. Release process: bump version → commit → push tag `v*.*.*` → CI runs E2E tests → creates GitHub Release with `.ankiaddon` artifact.
+
+### Source Install Mode (Nix)
+
+When installed from source (Nix, pip), vendored packages aren't used. `__init__.py` sets `_USING_SYSTEM_PACKAGES = True` and skips vendor path setup + conflict detection. The flag is toggled by checking whether system packages are importable before prepending the vendor path.
+
+### No Linter / Formatter
+
+This project has no pyproject.toml, ruff, flake8, or any configured linter. Don't try to run lint commands — they won't work.
+
 ### Profile Lifecycle
 
 - Server starts on `profile_did_open` hook
@@ -288,7 +300,7 @@ make e2e-down                   # Stop container
 
 **Server readiness**: `conftest.py` has a `session`-scoped `wait_for_server` fixture that polls the server up to `E2E_MAX_WAIT` seconds before any tests run — no need to manually wait.
 
-**Docker setup** (`.docker/`): The `docker-compose.yml` mounts `config.json` that binds the MCP server to `0.0.0.0` inside the container (instead of the default `127.0.0.1`) so the host can reach port 3141. It also mounts a custom `entrypoint.sh` that installs the `.ankiaddon` and starts headless Anki.
+**Docker setup** (`.docker/`): The `docker-compose.yml` mounts `config.json` that binds the MCP server to `0.0.0.0` inside the container (instead of the default `127.0.0.1`) so the host can reach port 3141. It also mounts a custom `entrypoint.sh` that installs the `.ankiaddon` and starts headless Anki. CI pins `ghcr.io/ankimcp/headless-anki:qt-vnc-v1.0.0`.
 
 **Debugging failed tests:**
 - `make e2e-debug` — keeps container running after start; VNC available at `localhost:5900`

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ Edit via Anki's *Tools → Add-ons → AnkiMCP Server → Config*:
   "cors_origins": [],
   "cors_expose_headers": ["mcp-session-id", "mcp-protocol-version"],
   "auto_connect_on_startup": true,
-  "disabled_tools": []
+  "disabled_tools": [],
+  "media_import_dir": "",
+  "media_allowed_types": [],
+  "media_allowed_hosts": []
 }
 ```
 
@@ -190,6 +193,28 @@ Use `["*"]` to allow all origins (not recommended for production).
 
 The `cors_expose_headers` setting controls which response headers browsers can read. The defaults (`mcp-session-id`, `mcp-protocol-version`) are required for the MCP Streamable HTTP protocol to work in browsers.
 
+### Media Security
+
+The `store_media_file` tool validates all inputs to prevent path traversal and SSRF attacks:
+
+- **File paths** are restricted to media files only (images, audio, video) via MIME type checking
+- **URLs** must use `http://` or `https://` and cannot target private/internal networks
+- **Filenames** are sanitized to remove path traversal sequences
+
+Optional hardening via config:
+
+```json
+{
+  "media_import_dir": "/Users/me/anki-media",
+  "media_allowed_types": ["application/pdf"],
+  "media_allowed_hosts": ["192.168.1.50", "my-nas.local"]
+}
+```
+
+- `media_import_dir` — restrict file path imports to this directory tree (empty = no restriction)
+- `media_allowed_types` — allow additional MIME types beyond image/audio/video
+- `media_allowed_hosts` — allow specific hosts to bypass private network blocking
+
 ## Available Tools
 
 ### Essential Tools
@@ -216,9 +241,9 @@ The `cors_expose_headers` setting controls which response headers browsers can r
 | `model_styling` | Get CSS styling for a note type |
 | `update_model_styling` | Update CSS styling for a note type |
 | `create_model` | Create a new note type |
-| `store_media_file` | Store a media file (image/audio) |
+| `store_media_file` | Store a media file (image/audio) via base64, file path, or URL. File paths are validated against a media-type allowlist; URLs are checked for SSRF |
 | `get_media_files_names` | List media files matching a pattern |
-| `delete_media_file` | Delete a media file |
+| `delete_media_file` | Move a media file to Anki's trash (recoverable via Check Media) |
 
 ### FSRS Tools
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The `cors_expose_headers` setting controls which response headers browsers can r
 
 ### Media Security
 
+> Thanks to **Hideaki Takahashi** (Columbia University) for responsibly disclosing the media path traversal vulnerability.
+
 The `store_media_file` tool validates all inputs to prevent path traversal and SSRF attacks:
 
 - **File paths** are restricted to media files only (images, audio, video) via MIME type checking

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The `cors_expose_headers` setting controls which response headers browsers can r
 
 ### Media Security
 
-> Thanks to **Hideaki Takahashi** (Columbia University) for responsibly disclosing the media path traversal vulnerability.
+> Thanks to **[Hideaki Takahashi](https://github.com/Koukyosyumei)** (Columbia University) for responsibly disclosing the media path traversal vulnerability.
 
 The `store_media_file` tool validates all inputs to prevent path traversal and SSRF attacks:
 

--- a/anki_mcp_server/__init__.py
+++ b/anki_mcp_server/__init__.py
@@ -17,7 +17,7 @@ if sys.version_info < (3, 10):
 
 from pathlib import Path
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 # Packages we vendor — used for conflict detection AND system-package fallback checks
 _VENDOR_PACKAGES = ['mcp', 'pydantic', 'pydantic_core', 'starlette', 'uvicorn', 'anyio', 'httpx', 'websockets']

--- a/anki_mcp_server/config.json
+++ b/anki_mcp_server/config.json
@@ -6,5 +6,8 @@
   "cors_origins": [],
   "cors_expose_headers": ["mcp-session-id", "mcp-protocol-version"],
   "disabled_tools": [],
+  "media_import_dir": "",
+  "media_allowed_types": [],
+  "media_allowed_hosts": [],
   "auto_connect_on_startup": true
 }

--- a/anki_mcp_server/config.py
+++ b/anki_mcp_server/config.py
@@ -40,6 +40,19 @@ class Config:
     # Example: ["get_fsrs_params", "card_management:bury", "card_management:unbury"]
     disabled_tools: List[str] = field(default_factory=list)
 
+    # Media security settings
+    # Restrict file path imports to this directory (empty = no restriction, any directory allowed)
+    # Example: "/Users/me/anki-media"
+    media_import_dir: str = ""
+
+    # Additional MIME types to allow beyond image/audio/video
+    # Example: ["application/pdf", "application/zip"]
+    media_allowed_types: List[str] = field(default_factory=list)
+
+    # Hosts/IPs allowed to bypass private network blocking for URL imports
+    # Example: ["192.168.1.50", "my-nas.local"]
+    media_allowed_hosts: List[str] = field(default_factory=list)
+
     # General
     auto_connect_on_startup: bool = True
 

--- a/anki_mcp_server/media_validators.py
+++ b/anki_mcp_server/media_validators.py
@@ -1,0 +1,339 @@
+"""Validation module for media tools — prevents path traversal and SSRF attacks.
+
+All media-related inputs (file paths, URLs, filenames) must pass through these
+validators before any I/O occurs. Each validator raises a specific HandlerError
+subclass with an actionable hint for the AI client, while logging security-relevant
+details (resolved paths, detected MIME types, resolved IPs) at WARNING level
+for the addon operator's audit trail.
+
+Only stdlib dependencies — no third-party packages.
+"""
+
+import ipaddress
+import logging
+import mimetypes
+import os
+import socket
+import urllib.parse
+from pathlib import Path
+from typing import Optional
+
+from .handler_wrappers import HandlerError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default allowed MIME type prefixes for media files
+# ---------------------------------------------------------------------------
+_DEFAULT_MEDIA_PREFIXES = ("image/", "audio/", "video/")
+
+
+# ---------------------------------------------------------------------------
+# Custom error classes
+# ---------------------------------------------------------------------------
+
+class MediaFileTypeError(HandlerError):
+    """File extension is not in the allowed MIME types for media import."""
+
+    def __init__(self, filename: str) -> None:
+        super().__init__(
+            "File type not allowed for media import",
+            hint=(
+                "Only image, audio, and video files are allowed. "
+                "Check the file extension and try again."
+            ),
+            code="validation_error",
+            filename=filename,
+        )
+
+
+class MediaImportDirError(HandlerError):
+    """Resolved file path falls outside the allowed import directory."""
+
+    def __init__(self, filename: str) -> None:
+        super().__init__(
+            "File path is outside the allowed import directory",
+            hint=(
+                "The file must be located inside the configured import directory. "
+                "Move the file there or adjust the import_dir setting."
+            ),
+            code="validation_error",
+            filename=filename,
+        )
+
+
+class MediaUrlSchemeError(HandlerError):
+    """URL uses a non-HTTP(S) scheme."""
+
+    def __init__(self, scheme: str) -> None:
+        super().__init__(
+            f"URL scheme '{scheme}' is not allowed",
+            hint="Only http and https URLs are supported.",
+            code="validation_error",
+        )
+
+
+class MediaUrlBlockedError(HandlerError):
+    """URL resolves to a private, reserved, loopback, or otherwise blocked IP."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "URL target is blocked",
+            hint=(
+                "The URL points to a restricted network address. "
+                "Use a publicly routable URL instead."
+            ),
+            code="validation_error",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part 2: File path validation
+# ---------------------------------------------------------------------------
+
+def validate_media_file_path(
+    file_path: str,
+    *,
+    allowed_types: Optional[list[str]] = None,
+    import_dir: Optional[str] = None,
+) -> Path:
+    """Validate and resolve a media file path.
+
+    Canonicalizes the path, checks the MIME type against an allow-list, and
+    optionally enforces that the file lives inside a specific directory.
+
+    Args:
+        file_path: Raw file path string from the client.
+        allowed_types: Extra MIME types to permit beyond the defaults
+            (e.g. ``["application/pdf"]``).
+        import_dir: If set, the resolved path must be inside this directory.
+
+    Returns:
+        The resolved ``pathlib.Path``.
+
+    Raises:
+        MediaFileTypeError: Extension maps to a disallowed or unknown MIME type,
+            or the path contains null bytes.
+        MediaImportDirError: Resolved path is outside *import_dir*.
+    """
+    # 1. Reject null bytes early — classic path injection vector.
+    if "\0" in file_path:
+        logger.warning(
+            "Null byte in file path rejected: %r", file_path[:120]
+        )
+        raise MediaFileTypeError(os.path.basename(file_path.replace("\0", "")))
+
+    # 2. Canonicalize (collapses ../, resolves symlinks).
+    resolved = Path(file_path).resolve()
+
+    # 3. Detect MIME type from extension.
+    mime_type, _ = mimetypes.guess_type(resolved.name)
+
+    # 4. Build the effective allow-set.
+    extra: set[str] = set(allowed_types) if allowed_types else set()
+
+    def _is_allowed(mt: Optional[str]) -> bool:
+        if mt is None:
+            return False
+        if mt in extra:
+            return True
+        return any(mt.startswith(prefix) for prefix in _DEFAULT_MEDIA_PREFIXES)
+
+    # 5. Audit log — always, regardless of outcome.
+    logger.warning(
+        "Media file path validation: resolved=%s, mime=%s", resolved, mime_type
+    )
+
+    # 6. Reject disallowed / unknown types.
+    if not _is_allowed(mime_type):
+        raise MediaFileTypeError(resolved.name)
+
+    # 7. Directory confinement check.
+    if import_dir:
+        allowed_root = Path(import_dir).resolve()
+        # Use os.sep suffix trick so "/tmp/evil" doesn't match "/tmp/ev".
+        if not (
+            str(resolved).startswith(str(allowed_root) + os.sep)
+        ):
+            logger.warning(
+                "Path traversal blocked: resolved=%s, allowed_root=%s",
+                resolved,
+                allowed_root,
+            )
+            raise MediaImportDirError(resolved.name)
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Part 3: URL validation
+# ---------------------------------------------------------------------------
+
+def _check_ip_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if the IP address belongs to a restricted range."""
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_media_url(
+    url: str,
+    *,
+    allowed_hosts: Optional[list[str]] = None,
+) -> str:
+    """Validate a media URL against SSRF vectors.
+
+    Parses the URL, enforces HTTP(S), resolves the hostname to an IP via DNS,
+    and blocks private / reserved / loopback addresses unless the host is
+    explicitly allow-listed.
+
+    Args:
+        url: Raw URL string from the client.
+        allowed_hosts: Hostnames or IP strings that bypass the private-range
+            check (e.g. ``["media.example.com", "10.0.0.5"]``).
+
+    Returns:
+        The original *url* string (unchanged) if validation passes.
+
+    Raises:
+        MediaUrlBlockedError: URL is malformed, hostname cannot be resolved,
+            or the resolved IP is in a restricted range.
+        MediaUrlSchemeError: Scheme is not ``http`` or ``https``.
+
+    Note:
+        This validation is subject to DNS rebinding (TOCTOU). The IP is resolved
+        and checked here, but the actual HTTP client will re-resolve the hostname
+        when fetching. An attacker controlling DNS could return a public IP for
+        this check and a private IP for the actual fetch. This is an inherent
+        limitation when the validator cannot control the downstream HTTP client.
+
+    Also note: urllib.request.urlopen follows HTTP redirects by default.
+    An attacker can host a public URL that 302-redirects to a private IP.
+    The initial URL passes validation but the redirect target is not checked.
+    This is a known limitation shared with the Node.js CLI implementation.
+    """
+    # 1. Parse.
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        raise MediaUrlBlockedError()
+
+    # 2. Scheme check — before hostname, because non-HTTP schemes (file:, ftp:)
+    #    often have no hostname and we want the specific error, not a generic block.
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise MediaUrlSchemeError(scheme or "<empty>")
+
+    if not parsed.hostname:
+        raise MediaUrlBlockedError()
+
+    hostname = parsed.hostname
+    safe_hosts: set[str] = {h.lower() for h in allowed_hosts} if allowed_hosts else set()
+
+    # 3. DNS resolution — socket.getaddrinfo handles IPv4 and IPv6.
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        logger.warning("DNS resolution failed for hostname: %s", hostname)
+        raise MediaUrlBlockedError()
+
+    if not addr_infos:
+        raise MediaUrlBlockedError()
+
+    # Check every resolved address — a hostname can resolve to multiple IPs.
+    for family, _type, _proto, _canonname, sockaddr in addr_infos:
+        ip_str = sockaddr[0]
+        ip = ipaddress.ip_address(ip_str)
+
+        # 4. Audit log.
+        logger.warning(
+            "Media URL validation: hostname=%s, resolved_ip=%s", hostname, ip
+        )
+
+        # 5. Allow-list bypass.
+        if hostname in safe_hosts or ip_str in safe_hosts:
+            continue
+
+        # 6. Restricted-range check.
+        if _check_ip_blocked(ip):
+            raise MediaUrlBlockedError()
+
+        # 7. IPv4-mapped IPv6 (e.g. ::ffff:192.168.1.1).
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            if _check_ip_blocked(ip.ipv4_mapped):
+                raise MediaUrlBlockedError()
+
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Part 4: Filename sanitisation
+# ---------------------------------------------------------------------------
+
+def validate_media_filename_type(
+    filename: str,
+    *,
+    allowed_types: list[str] | None = None,
+) -> None:
+    """Validate that a filename has an allowed media MIME type.
+
+    Unlike validate_media_file_path which validates a full file path,
+    this only checks the filename's extension against the MIME allowlist.
+    Use this for data/URL sources where there's no path to validate.
+
+    Args:
+        filename: The filename to check (already sanitized).
+        allowed_types: Extra MIME types beyond defaults.
+
+    Raises:
+        MediaFileTypeError: Extension maps to a disallowed or unknown MIME type.
+    """
+    mime_type, _ = mimetypes.guess_type(filename)
+    extra: set[str] = set(allowed_types) if allowed_types else set()
+
+    def _is_allowed(mt: str | None) -> bool:
+        if mt is None:
+            return False
+        if mt in extra:
+            return True
+        return any(mt.startswith(prefix) for prefix in _DEFAULT_MEDIA_PREFIXES)
+
+    if not _is_allowed(mime_type):
+        logger.warning("Filename MIME check failed: filename=%s, mime=%s", filename, mime_type)
+        raise MediaFileTypeError(filename)
+
+
+def sanitize_media_filename(filename: str) -> str:
+    """Sanitize a filename for safe storage in Anki's media folder.
+
+    Strips dangerous characters and sequences that could cause path traversal
+    or other filesystem surprises.
+
+    Args:
+        filename: Raw filename string (not a full path).
+
+    Returns:
+        A safe, non-empty filename string.
+    """
+    # 1. Null bytes.
+    name = filename.replace("\0", "")
+    # 2. Path separators — remove BEFORE traversal sequences so that
+    #    inputs like "./" can't recombine into ".." after separator removal.
+    name = name.replace("/", "").replace("\\", "")
+    # 3. Directory traversal sequences — loop because removal can create
+    #    new ".." sequences (e.g. "....//" → after step 2 → "...." → "..").
+    while ".." in name:
+        name = name.replace("..", "")
+    # 4. Basename (defence-in-depth after separator removal).
+    name = os.path.basename(name)
+    # 5. Whitespace.
+    name = name.strip()
+    # 6. Empty / dot-only guard.
+    if not name or name in (".", ".."):
+        return "unnamed"
+    return name

--- a/anki_mcp_server/primitives/essential/tools/delete_media_file_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/delete_media_file_tool.py
@@ -3,14 +3,14 @@ import os
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ....media_validators import sanitize_media_filename
 
 
 @Tool(
     "delete_media_file",
-    "Delete a media file from Anki's media folder. This will permanently remove "
-    "the file from disk. This action cannot be undone unless you have a backup. "
-    "CRITICAL: This is destructive and permanent - only delete files the user "
-    "explicitly confirmed for deletion.",
+    "Move a media file to Anki's trash folder. The file can be recovered via "
+    "Anki's 'Check Media' dialog until the trash is emptied. Sync to propagate "
+    "the deletion to other devices. Confirm with the user before deleting.",
     write=True,
 )
 def delete_media_file(filename: str) -> dict[str, Any]:
@@ -19,17 +19,7 @@ def delete_media_file(filename: str) -> dict[str, Any]:
     if not filename or not filename.strip():
         raise HandlerError("Filename cannot be empty")
 
-    if os.path.sep in filename or (os.path.altsep and os.path.altsep in filename):
-        raise HandlerError(
-            f"Filename cannot contain path separators. Got: {filename}",
-            hint="Use only the filename without directory paths",
-        )
-
-    if ".." in filename or filename.startswith("."):
-        raise HandlerError(
-            f"Filename cannot contain relative path indicators (./ or ../). Got: {filename}",
-            hint="Use only the filename without relative path components",
-        )
+    filename = sanitize_media_filename(filename)
 
     media_dir = col.media.dir()
     file_path = os.path.join(media_dir, filename)
@@ -46,18 +36,11 @@ def delete_media_file(filename: str) -> dict[str, Any]:
             hint="Cannot delete directories",
         )
 
-    try:
-        os.remove(file_path)
-    except PermissionError:
-        raise HandlerError(
-            f"Permission denied when trying to delete {filename}",
-            hint="The file may be in use by another process",
-        )
+    col.media.trash_files([filename])
 
     return {
         "filename": filename,
         "path": file_path,
-        "message": f"Successfully deleted media file: {filename}",
-        "warning": "This file has been permanently deleted from the media folder",
-        "hint": "Consider syncing with AnkiWeb to propagate deletion to other devices",
+        "message": f"Successfully moved media file to trash: {filename}",
+        "hint": "File can be recovered via Anki's 'Check Media' dialog. Sync to propagate deletion to other devices.",
     }

--- a/anki_mcp_server/primitives/essential/tools/store_media_file_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/store_media_file_tool.py
@@ -6,6 +6,22 @@ from pathlib import Path
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ....media_validators import (
+    validate_media_file_path,
+    validate_media_url,
+    sanitize_media_filename,
+    validate_media_filename_type,
+)
+from ....config import Config
+
+
+def _load_config() -> Config:
+    """Load addon config from Anki's config manager."""
+    from aqt import mw
+
+    addon_package = __name__.split(".")[0]
+    raw = mw.addonManager.getConfig(addon_package) or {}
+    return Config.from_dict(raw)
 
 
 def _get_file_bytes(
@@ -13,8 +29,12 @@ def _get_file_bytes(
     path: Optional[str],
     url: Optional[str],
     filename: str,
+    config: Config,
 ) -> tuple[bytes, str]:
     """Get file bytes from one of three sources.
+
+    Validates path and URL inputs against security policies from config
+    before performing any I/O.
 
     Returns:
         Tuple of (file_bytes, source_type)
@@ -30,16 +50,22 @@ def _get_file_bytes(
             )
 
     if path is not None:
-        file_path = Path(path)
+        # Validate before any filesystem I/O — checks MIME type and
+        # directory confinement per addon config.
+        resolved = validate_media_file_path(
+            path,
+            allowed_types=config.media_allowed_types or None,
+            import_dir=config.media_import_dir or None,
+        )
 
-        if not file_path.exists():
+        if not resolved.exists():
             raise HandlerError(f"File not found: {path}", filename=filename)
 
-        if not file_path.is_file():
+        if not resolved.is_file():
             raise HandlerError(f"Path is not a file: {path}", filename=filename)
 
         try:
-            return file_path.read_bytes(), "file"
+            return resolved.read_bytes(), "file"
         except Exception as e:
             raise HandlerError(
                 f"Failed to read file: {e}",
@@ -48,6 +74,13 @@ def _get_file_bytes(
             )
 
     if url is not None:
+        # Validate before any network I/O — checks scheme and blocks
+        # private/reserved IPs unless allow-listed in addon config.
+        validate_media_url(
+            url,
+            allowed_hosts=config.media_allowed_hosts or None,
+        )
+
         try:
             with urllib.request.urlopen(url, timeout=30) as response:
                 return response.read(), "url"
@@ -104,9 +137,18 @@ def store_media_file(
     if not filename or not filename.strip():
         raise HandlerError("Filename cannot be empty")
 
-    filename = filename.strip()
+    filename = sanitize_media_filename(filename)
 
-    file_bytes, source_type = _get_file_bytes(data, path, url, filename)
+    config = _load_config()
+
+    # MIME check on filename for all source types (path source gets additional
+    # path-level validation inside _get_file_bytes)
+    validate_media_filename_type(
+        filename,
+        allowed_types=config.media_allowed_types or None,
+    )
+
+    file_bytes, source_type = _get_file_bytes(data, path, url, filename, config)
 
     if not file_bytes:
         raise HandlerError("File data is empty", filename=filename)

--- a/ankiweb-description.html
+++ b/ankiweb-description.html
@@ -17,7 +17,14 @@ AI-powered study sessions, card creation, and collection management.</p>
 <li><b>CORS support</b> - Configurable origins for browser-based MCP clients</li>
 </ul>
 
-<h2>What's New in v0.13</h2>
+<h2>What's New in v0.14</h2>
+<ul>
+<li><b>Security: Media file validation</b> - <code>store_media_file</code> now validates all inputs: file paths are restricted to media types (images, audio, video) via MIME checking, URLs are checked for SSRF (private network blocking), and filenames are sanitized against path traversal</li>
+<li><b>Security: Configurable hardening</b> - New config options <code>media_import_dir</code> (restrict file imports to a directory), <code>media_allowed_types</code> (allow additional MIME types), and <code>media_allowed_hosts</code> (allow specific private hosts for URL imports)</li>
+<li><b>Fix: delete_media_file uses Anki's trash</b> - Files are now moved to Anki's trash folder instead of permanent deletion. Recoverable via Check Media, and deletions propagate correctly on sync</li>
+</ul>
+
+<h2>v0.13 Highlights</h2>
 <ul>
 <li><b>NixOS support</b> - Ships a <code>flake.nix</code> for one-line NixOS installs. Source-based installs now detect system-provided packages instead of crashing</li>
 <li><b>Source install support</b> - When <code>vendor/</code> is missing (pip from source, Nix, Guix), the addon falls back to system packages with a clear error if any are missing</li>
@@ -97,9 +104,9 @@ AI-powered study sessions, card creation, and collection management.</p>
 <li><b>model_styling</b> - Get CSS styling for a note type</li>
 <li><b>update_model_styling</b> - Update CSS styling for a note type</li>
 <li><b>create_model</b> - Create a new note type</li>
-<li><b>store_media_file</b> - Store a media file (image/audio)</li>
+<li><b>store_media_file</b> - Store a media file (image/audio) via base64, file path, or URL. Validates media type and blocks SSRF</li>
 <li><b>get_media_files_names</b> - List media files matching a pattern</li>
-<li><b>delete_media_file</b> - Delete a media file</li>
+<li><b>delete_media_file</b> - Move a media file to Anki's trash (recoverable via Check Media)</li>
 </ul>
 
 <h3>Multi-Action Tools</h3>
@@ -156,7 +163,10 @@ AI-powered study sessions, card creation, and collection management.</p>
   "http_path": "",
   "cors_origins": [],
   "auto_connect_on_startup": true,
-  "disabled_tools": []
+  "disabled_tools": [],
+  "media_import_dir": "",
+  "media_allowed_types": [],
+  "media_allowed_hosts": []
 }
 </pre>
 

--- a/ankiweb-description.html
+++ b/ankiweb-description.html
@@ -23,6 +23,7 @@ AI-powered study sessions, card creation, and collection management.</p>
 <li><b>Security: Configurable hardening</b> - New config options <code>media_import_dir</code> (restrict file imports to a directory), <code>media_allowed_types</code> (allow additional MIME types), and <code>media_allowed_hosts</code> (allow specific private hosts for URL imports)</li>
 <li><b>Fix: delete_media_file uses Anki's trash</b> - Files are now moved to Anki's trash folder instead of permanent deletion. Recoverable via Check Media, and deletions propagate correctly on sync</li>
 </ul>
+<p>Thanks to <b>Hideaki Takahashi</b> (Columbia University) for responsibly disclosing the media path traversal vulnerability.</p>
 
 <h2>v0.13 Highlights</h2>
 <ul>

--- a/ankiweb-description.html
+++ b/ankiweb-description.html
@@ -23,7 +23,7 @@ AI-powered study sessions, card creation, and collection management.</p>
 <li><b>Security: Configurable hardening</b> - New config options <code>media_import_dir</code> (restrict file imports to a directory), <code>media_allowed_types</code> (allow additional MIME types), and <code>media_allowed_hosts</code> (allow specific private hosts for URL imports)</li>
 <li><b>Fix: delete_media_file uses Anki's trash</b> - Files are now moved to Anki's trash folder instead of permanent deletion. Recoverable via Check Media, and deletions propagate correctly on sync</li>
 </ul>
-<p>Thanks to <b>Hideaki Takahashi</b> (Columbia University) for responsibly disclosing the media path traversal vulnerability.</p>
+<p>Thanks to <b><a href="https://github.com/Koukyosyumei">Hideaki Takahashi</a></b> (Columbia University) for responsibly disclosing the media path traversal vulnerability.</p>
 
 <h2>v0.13 Highlights</h2>
 <ul>

--- a/tests/e2e/test_media_security.py
+++ b/tests/e2e/test_media_security.py
@@ -1,0 +1,119 @@
+"""E2E tests for media security — path traversal and SSRF prevention."""
+from __future__ import annotations
+
+import pytest
+
+from .helpers import call_tool
+
+
+# 1x1 transparent PNG, valid base64
+TINY_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
+    "DUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+class TestPathTraversalBlocked:
+    """Verify that store_media_file rejects dangerous path values.
+
+    Validation happens BEFORE any file I/O, so these tests work even though
+    the referenced files don't exist inside the Docker container.
+    """
+
+    @pytest.mark.parametrize(
+        "path, reason",
+        [
+            ("/etc/passwd", "no media extension"),
+            ("/home/user/.ssh/id_rsa", "no extension"),
+            ("/home/user/.env", "dotfile, no media MIME type"),
+            ("/home/user/secrets.json", "JSON not allowed"),
+            ("/home/user/data.csv", "CSV not allowed"),
+            ("/tmp/noextension", "no extension at all"),
+        ],
+        ids=[
+            "etc_passwd",
+            "ssh_key",
+            "dotfile",
+            "json",
+            "csv",
+            "no_extension",
+        ],
+    )
+    def test_path_rejected(self, path: str, reason: str):
+        """Path with non-media MIME type should be rejected."""
+        result = call_tool("store_media_file", {
+            "filename": "test.jpg",
+            "path": path,
+        })
+        assert result.get("isError") is True, (
+            f"Expected error for path={path!r} ({reason}), got: {result}"
+        )
+        # Verify rejection is from MIME validator, not file-not-found
+        result_str = str(result).lower()
+        assert "not allowed" in result_str or "file type" in result_str, (
+            f"Expected MIME type rejection but got: {result}"
+        )
+
+
+class TestSsrfBlocked:
+    """Verify that store_media_file rejects dangerous URL schemes.
+
+    Private IP blocking is covered by unit tests — it requires DNS resolution
+    that may behave differently inside Docker. Scheme validation is deterministic.
+    """
+
+    @pytest.mark.parametrize(
+        "url, reason",
+        [
+            ("file:///etc/passwd", "file:// scheme"),
+            ("ftp://evil.com/file.jpg", "ftp:// scheme"),
+            ("gopher://evil.com/", "gopher:// scheme"),
+        ],
+        ids=["file_scheme", "ftp_scheme", "gopher_scheme"],
+    )
+    def test_url_scheme_rejected(self, url: str, reason: str):
+        """Non-HTTP(S) URL schemes should be rejected."""
+        result = call_tool("store_media_file", {
+            "filename": "test.jpg",
+            "url": url,
+        })
+        assert result.get("isError") is True, (
+            f"Expected error for url={url!r} ({reason}), got: {result}"
+        )
+
+    def test_loopback_url_blocked(self):
+        """http://127.0.0.1 should be blocked by IP range check, not just scheme."""
+        result = call_tool("store_media_file", {
+            "filename": "test.jpg",
+            "url": "http://127.0.0.1/image.jpg",
+        })
+        assert result.get("isError") is True
+
+
+class TestFilenameSanitization:
+    """Verify that filenames with traversal sequences are sanitized."""
+
+    def test_dotdot_stripped_from_filename(self):
+        """Filename '../../evil.png' should be sanitized — no '..' or '/' in result."""
+        result = call_tool("store_media_file", {
+            "filename": "../../evil.png",
+            "data": TINY_PNG_B64,
+        })
+        assert result.get("isError") is not True, (
+            f"Store should succeed after sanitization, got: {result}"
+        )
+        actual_name = result["filename"]
+        assert ".." not in actual_name, f"Traversal sequence in filename: {actual_name}"
+        assert "/" not in actual_name, f"Path separator in filename: {actual_name}"
+
+    def test_slashes_stripped_from_filename(self):
+        """Filename 'path/to/file.png' should have slashes removed."""
+        result = call_tool("store_media_file", {
+            "filename": "path/to/file.png",
+            "data": TINY_PNG_B64,
+        })
+        assert result.get("isError") is not True, (
+            f"Store should succeed after sanitization, got: {result}"
+        )
+        actual_name = result["filename"]
+        assert "/" not in actual_name, f"Path separator in filename: {actual_name}"

--- a/tests/e2e/test_media_tools.py
+++ b/tests/e2e/test_media_tools.py
@@ -1,0 +1,125 @@
+"""E2E tests for media tools — store, list, delete."""
+from __future__ import annotations
+
+import pytest
+
+from .conftest import unique_id
+from .helpers import call_tool
+
+
+# 1x1 transparent PNG, valid base64
+TINY_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
+    "DUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def _store_test_file(filename: str | None = None) -> dict:
+    """Store a tiny PNG and return the result. Generates a unique filename if none given."""
+    if filename is None:
+        filename = f"e2e_test_{unique_id()}.png"
+    result = call_tool("store_media_file", {
+        "filename": filename,
+        "data": TINY_PNG_B64,
+    })
+    assert result.get("isError") is not True, f"Failed to store test file: {result}"
+    return result
+
+
+class TestStoreMediaFile:
+    """Tests for store_media_file tool."""
+
+    def test_store_via_base64(self):
+        """Storing a valid base64 image should return filename and size."""
+        result = _store_test_file()
+        assert "filename" in result
+        assert result["size"] > 0
+        assert "message" in result
+
+    @pytest.mark.skip(reason="MCP Inspector CLI rejects empty --tool-arg values before they reach the server")
+    def test_store_empty_filename_fails(self):
+        """Empty filename should be rejected."""
+        result = call_tool("store_media_file", {
+            "filename": "",
+            "data": TINY_PNG_B64,
+        })
+        assert result.get("isError") is True
+
+    def test_store_no_source_fails(self):
+        """Calling without data, path, or url should error."""
+        result = call_tool("store_media_file", {
+            "filename": "orphan.png",
+        })
+        assert result.get("isError") is True
+
+    def test_store_multiple_sources_fails(self):
+        """Providing both data AND path should error."""
+        result = call_tool("store_media_file", {
+            "filename": "multi.png",
+            "data": TINY_PNG_B64,
+            "path": "/tmp/fake.png",
+        })
+        assert result.get("isError") is True
+
+
+class TestGetMediaFilesNames:
+    """Tests for get_media_files_names tool."""
+
+    def test_list_media_files(self):
+        """After storing a file, listing should include it."""
+        stored = _store_test_file()
+        stored_name = stored["filename"]
+
+        result = call_tool("get_media_files_names", {})
+        assert result["total"] > 0
+        assert stored_name in result["files"]
+
+    def test_list_with_pattern(self):
+        """Pattern filter should match our uniquely-named file."""
+        uid = unique_id()
+        filename = f"e2e_pattern_{uid}.png"
+        _store_test_file(filename)
+
+        result = call_tool("get_media_files_names", {
+            "pattern": f"*{uid}*",
+        })
+        assert result["total"] == 1
+        assert filename in result["files"]
+
+    def test_list_with_no_matches(self):
+        """Pattern that matches nothing should return empty list."""
+        result = call_tool("get_media_files_names", {
+            "pattern": "zzz_nonexistent_pattern_zzz_*.xyz",
+        })
+        assert result["total"] == 0
+        assert result["files"] == []
+
+
+class TestDeleteMediaFile:
+    """Tests for delete_media_file tool."""
+
+    def test_delete_stored_file(self):
+        """Deleting a stored file should succeed and mention trash."""
+        stored = _store_test_file()
+        filename = stored["filename"]
+
+        result = call_tool("delete_media_file", {"filename": filename})
+        assert result.get("isError") is not True, f"Delete failed: {result}"
+        assert "trash" in result["message"].lower()
+
+        # Verify file is actually gone from media listing
+        listing = call_tool("get_media_files_names", {"pattern": filename})
+        assert filename not in listing.get("files", [])
+
+    def test_delete_nonexistent_file(self):
+        """Deleting a file that doesn't exist should error."""
+        result = call_tool("delete_media_file", {
+            "filename": f"nonexistent_{unique_id()}.png",
+        })
+        assert result.get("isError") is True
+
+    @pytest.mark.skip(reason="MCP Inspector CLI rejects empty --tool-arg values before they reach the server")
+    def test_delete_empty_filename_fails(self):
+        """Empty filename should be rejected."""
+        result = call_tool("delete_media_file", {"filename": ""})
+        assert result.get("isError") is True

--- a/tests/unit/test_media_validators.py
+++ b/tests/unit/test_media_validators.py
@@ -1,0 +1,512 @@
+"""Unit tests for anki_mcp_server.media_validators.
+
+Tests cover all three public functions: validate_media_file_path,
+validate_media_url, and sanitize_media_filename.  Organised by function,
+one class per function, following the existing test style in
+test_tool_filtering.py.
+"""
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from anki_mcp_server.media_validators import (
+    MediaFileTypeError,
+    MediaImportDirError,
+    MediaUrlBlockedError,
+    MediaUrlSchemeError,
+    sanitize_media_filename,
+    validate_media_file_path,
+    validate_media_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking socket.getaddrinfo
+# ---------------------------------------------------------------------------
+
+def _fake_addrinfo(ip: str, family: int = socket.AF_INET):
+    """Build a single getaddrinfo result tuple for a given IP string."""
+    return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 0))]
+
+
+def _patch_dns(ip: str, family: int = socket.AF_INET):
+    """Return a ``patch`` context that makes every DNS lookup resolve to *ip*."""
+    return patch(
+        "anki_mcp_server.media_validators.socket.getaddrinfo",
+        return_value=_fake_addrinfo(ip, family),
+    )
+
+
+# ===========================================================================
+# validate_media_file_path
+# ===========================================================================
+
+
+class TestValidateMediaFilePath:
+    """Tests for validate_media_file_path()."""
+
+    # ---- Allowed extensions (image) ----------------------------------------
+
+    @pytest.mark.parametrize("ext", [
+        ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".bmp", ".ico",
+    ])
+    def test_image_extensions_allowed(self, tmp_path: Path, ext: str):
+        f = tmp_path / f"photo{ext}"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f))
+        assert result == f.resolve()
+
+    # ---- Allowed extensions (audio) ----------------------------------------
+
+    @pytest.mark.parametrize("ext", [
+        ".mp3", ".wav", ".ogg", ".flac", ".m4a", ".aac",
+    ])
+    def test_audio_extensions_allowed(self, tmp_path: Path, ext: str):
+        f = tmp_path / f"clip{ext}"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f))
+        assert result == f.resolve()
+
+    # ---- Allowed extensions (video) ----------------------------------------
+
+    @pytest.mark.parametrize("ext", [
+        ".mp4", ".webm", ".avi", ".mkv", ".mov",
+    ])
+    def test_video_extensions_allowed(self, tmp_path: Path, ext: str):
+        f = tmp_path / f"movie{ext}"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f))
+        assert result == f.resolve()
+
+    # ---- Blocked file types ------------------------------------------------
+
+    @pytest.mark.parametrize("filename", [
+        "credentials.json",
+        "script.py",
+        "data.csv",
+        "archive.zip",
+        "document.pdf",
+    ])
+    def test_blocked_extensions(self, tmp_path: Path, filename: str):
+        f = tmp_path / filename
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path(str(f))
+
+    @pytest.mark.parametrize("filename", [
+        "id_rsa",               # no extension (ssh key)
+        "file_with_no_extension",
+    ])
+    def test_blocked_no_extension(self, tmp_path: Path, filename: str):
+        f = tmp_path / filename
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path(str(f))
+
+    def test_blocked_dotfile_env(self, tmp_path: Path):
+        """Dotfiles like .env have no MIME type and should be blocked."""
+        f = tmp_path / ".env"
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path(str(f))
+
+    def test_blocked_etc_passwd(self, tmp_path: Path):
+        """/etc/passwd has no extension and should be blocked."""
+        f = tmp_path / "passwd"
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path(str(f))
+
+    # ---- Null byte injection -----------------------------------------------
+
+    def test_null_byte_in_path_raises(self):
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path("/etc/passwd\0.jpg")
+
+    def test_null_byte_complex_injection(self):
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path("/photos/image\0.ssh/id_rsa.jpg")
+
+    # ---- allowed_types config ----------------------------------------------
+
+    def test_allowed_types_pdf(self, tmp_path: Path):
+        """Extra allowed_types should permit otherwise-blocked MIME types."""
+        f = tmp_path / "document.pdf"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(
+            str(f), allowed_types=["application/pdf"]
+        )
+        assert result == f.resolve()
+
+    def test_default_types_still_work_with_extra(self, tmp_path: Path):
+        """Default media types remain allowed when extra types are set."""
+        f = tmp_path / "image.png"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(
+            str(f), allowed_types=["application/pdf"]
+        )
+        assert result == f.resolve()
+
+    def test_extra_types_dont_open_everything(self, tmp_path: Path):
+        """Adding one extra type does not allow unrelated types."""
+        f = tmp_path / "script.py"
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaFileTypeError):
+            validate_media_file_path(
+                str(f), allowed_types=["application/pdf"]
+            )
+
+    # ---- import_dir restriction --------------------------------------------
+
+    def test_file_inside_import_dir(self, tmp_path: Path):
+        f = tmp_path / "image.jpg"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f), import_dir=str(tmp_path))
+        assert result == f.resolve()
+
+    def test_file_in_subdirectory_of_import_dir(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        f = sub / "image.jpg"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f), import_dir=str(tmp_path))
+        assert result == f.resolve()
+
+    def test_file_outside_import_dir(self, tmp_path: Path):
+        import_dir = tmp_path / "allowed"
+        import_dir.mkdir()
+        f = tmp_path / "image.jpg"
+        f.write_bytes(b"\x00")
+        with pytest.raises(MediaImportDirError):
+            validate_media_file_path(str(f), import_dir=str(import_dir))
+
+    def test_path_traversal_blocked_by_import_dir(self, tmp_path: Path):
+        """../../../etc/passwd.jpg resolves outside import_dir."""
+        import_dir = tmp_path / "allowed"
+        import_dir.mkdir()
+        traversal = str(import_dir / ".." / ".." / ".." / "etc" / "passwd.jpg")
+        with pytest.raises(MediaImportDirError):
+            validate_media_file_path(traversal, import_dir=str(import_dir))
+
+    def test_empty_import_dir_means_no_restriction(self, tmp_path: Path):
+        """Empty string import_dir is treated as no restriction."""
+        f = tmp_path / "image.jpg"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f), import_dir="")
+        assert result == f.resolve()
+
+    def test_none_import_dir_means_no_restriction(self, tmp_path: Path):
+        """None import_dir is treated as no restriction."""
+        f = tmp_path / "image.jpg"
+        f.write_bytes(b"\x00")
+        result = validate_media_file_path(str(f), import_dir=None)
+        assert result == f.resolve()
+
+    # ---- Path resolution ---------------------------------------------------
+
+    def test_symlink_outside_import_dir_blocked(self, tmp_path: Path):
+        """Symlink pointing outside import_dir should be blocked after resolve()."""
+        import_dir = tmp_path / "allowed"
+        import_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        real_file = outside / "image.jpg"
+        real_file.write_bytes(b"\x00")
+
+        link = import_dir / "sneaky.jpg"
+        link.symlink_to(real_file)
+
+        with pytest.raises(MediaImportDirError):
+            validate_media_file_path(str(link), import_dir=str(import_dir))
+
+    def test_relative_path_resolves(self, tmp_path: Path, monkeypatch):
+        """Relative paths like ./image.jpg resolve against cwd."""
+        f = tmp_path / "image.jpg"
+        f.write_bytes(b"\x00")
+        monkeypatch.chdir(tmp_path)
+        result = validate_media_file_path("./image.jpg")
+        assert result == f.resolve()
+
+
+# ===========================================================================
+# validate_media_url
+# ===========================================================================
+
+
+class TestValidateMediaUrl:
+    """Tests for validate_media_url()."""
+
+    # ---- Allowed URLs ------------------------------------------------------
+
+    def test_http_public_url_allowed(self):
+        with _patch_dns("93.184.216.34"):
+            result = validate_media_url("http://example.com/image.jpg")
+        assert result == "http://example.com/image.jpg"
+
+    def test_https_public_url_allowed(self):
+        with _patch_dns("93.184.216.34"):
+            result = validate_media_url("https://cdn.example.com/photo.png")
+        assert result == "https://cdn.example.com/photo.png"
+
+    def test_url_with_port_allowed(self):
+        with _patch_dns("93.184.216.34"):
+            result = validate_media_url("http://example.com:8080/img.jpg")
+        assert result == "http://example.com:8080/img.jpg"
+
+    # ---- Blocked schemes ---------------------------------------------------
+
+    def test_file_scheme_blocked(self):
+        with pytest.raises(MediaUrlSchemeError) as exc_info:
+            validate_media_url("file:///etc/passwd")
+        assert "file" in str(exc_info.value)
+
+    def test_ftp_scheme_blocked(self):
+        with pytest.raises(MediaUrlSchemeError) as exc_info:
+            validate_media_url("ftp://files.example.com/image.jpg")
+        assert "ftp" in str(exc_info.value)
+
+    def test_gopher_scheme_blocked(self):
+        with pytest.raises(MediaUrlSchemeError):
+            validate_media_url("gopher://evil.com/")
+
+    def test_empty_scheme_blocked(self):
+        """URL with no scheme should raise MediaUrlSchemeError."""
+        with pytest.raises(MediaUrlSchemeError):
+            validate_media_url("example.com/image.jpg")
+
+    # ---- Blocked IPs (IPv4) ------------------------------------------------
+
+    @pytest.mark.parametrize("ip,label", [
+        ("10.0.0.1", "10.x private"),
+        ("172.16.0.1", "172.16.x private"),
+        ("192.168.1.1", "192.168.x private"),
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "link-local / cloud metadata"),
+        ("0.0.0.0", "unspecified"),
+        ("224.0.0.1", "multicast"),
+        ("255.255.255.255", "broadcast"),
+    ])
+    def test_blocked_ipv4(self, ip: str, label: str):
+        with _patch_dns(ip):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url(f"http://evil.example.com/{label}")
+
+    def test_carrier_grade_nat_not_blocked(self):
+        """100.64.0.1 (carrier-grade NAT) is NOT in Python's private ranges.
+
+        The stdlib ipaddress module does not classify 100.64.0.0/10 as
+        private, reserved, or any other restricted category.  This test
+        documents the actual behavior of the validator.
+        """
+        with _patch_dns("100.64.0.1"):
+            result = validate_media_url("http://cgnat.example.com/img.jpg")
+        assert result == "http://cgnat.example.com/img.jpg"
+
+    # ---- Blocked IPs (IPv6) ------------------------------------------------
+
+    def test_ipv6_loopback_blocked(self):
+        with _patch_dns("::1", family=socket.AF_INET6):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://ipv6host.example.com/img.jpg")
+
+    def test_ipv6_mapped_private_blocked(self):
+        """::ffff:192.168.1.1 is blocked (is_private=True on the IPv6 address itself)."""
+        with _patch_dns("::ffff:192.168.1.1", family=socket.AF_INET6):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://mapped.example.com/img.jpg")
+
+    def test_ipv6_unique_local_blocked(self):
+        with _patch_dns("fd00::1", family=socket.AF_INET6):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://ula.example.com/img.jpg")
+
+    def test_ipv6_public_allowed(self):
+        with _patch_dns("2607:f8b0:4004:800::200e", family=socket.AF_INET6):
+            result = validate_media_url("http://google.example.com/img.jpg")
+        assert result == "http://google.example.com/img.jpg"
+
+    # ---- allowed_hosts config ----------------------------------------------
+
+    def test_allowed_hosts_bypasses_private_ip(self):
+        """A hostname in allowed_hosts allows access even if IP is private."""
+        with _patch_dns("192.168.1.1"):
+            result = validate_media_url(
+                "http://internal.company.com/img.jpg",
+                allowed_hosts=["internal.company.com"],
+            )
+        assert result == "http://internal.company.com/img.jpg"
+
+    def test_allowed_hosts_by_ip_string(self):
+        """An IP string in allowed_hosts allows that specific IP."""
+        with _patch_dns("10.0.0.5"):
+            result = validate_media_url(
+                "http://media-server.local/img.jpg",
+                allowed_hosts=["10.0.0.5"],
+            )
+        assert result == "http://media-server.local/img.jpg"
+
+    def test_non_listed_host_still_blocked(self):
+        """Hosts not in allowed_hosts remain subject to IP checks."""
+        with _patch_dns("192.168.1.1"):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url(
+                    "http://evil.local/img.jpg",
+                    allowed_hosts=["safe.company.com"],
+                )
+
+    def test_allowed_hosts_case_insensitive(self):
+        """allowed_hosts should match case-insensitively since urlparse lowercases hostnames."""
+        with _patch_dns("192.168.1.1"):
+            # Mixed-case entry should still match lowered hostname
+            result = validate_media_url(
+                "http://internal.company.com/img.jpg",
+                allowed_hosts=["Internal.Company.Com"],
+            )
+            assert result == "http://internal.company.com/img.jpg"
+
+    # ---- DNS failure -------------------------------------------------------
+
+    def test_dns_failure_raises_blocked(self):
+        """socket.gaierror during DNS resolution should raise MediaUrlBlockedError."""
+        with patch(
+            "anki_mcp_server.media_validators.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name resolution failed"),
+        ):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://nonexistent.invalid/img.jpg")
+
+    # ---- Invalid URLs ------------------------------------------------------
+
+    def test_completely_invalid_url(self):
+        """A string that is not a URL at all."""
+        with pytest.raises((MediaUrlSchemeError, MediaUrlBlockedError)):
+            validate_media_url("not a url at all")
+
+    def test_empty_string(self):
+        with pytest.raises(MediaUrlSchemeError):
+            validate_media_url("")
+
+    def test_url_with_no_hostname(self):
+        """http:/// has scheme but no hostname."""
+        with pytest.raises(MediaUrlBlockedError):
+            validate_media_url("http:///path/to/file")
+
+    # ---- Multiple resolved IPs ---------------------------------------------
+
+    def test_all_ips_must_be_safe(self):
+        """If a hostname resolves to multiple IPs and one is private, block."""
+        mixed_results = [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("192.168.1.1", 0)),
+        ]
+        with patch(
+            "anki_mcp_server.media_validators.socket.getaddrinfo",
+            return_value=mixed_results,
+        ):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://dual-homed.example.com/img.jpg")
+
+    def test_empty_addrinfo_raises(self):
+        """If getaddrinfo returns empty list, should raise."""
+        with patch(
+            "anki_mcp_server.media_validators.socket.getaddrinfo",
+            return_value=[],
+        ):
+            with pytest.raises(MediaUrlBlockedError):
+                validate_media_url("http://empty-dns.example.com/img.jpg")
+
+
+# ===========================================================================
+# sanitize_media_filename
+# ===========================================================================
+
+
+class TestSanitizeMediaFilename:
+    """Tests for sanitize_media_filename()."""
+
+    # ---- Simple filenames (no change) --------------------------------------
+
+    def test_simple_filename(self):
+        assert sanitize_media_filename("image.jpg") == "image.jpg"
+
+    def test_filename_with_spaces_and_parens(self):
+        assert sanitize_media_filename("my file (1).jpg") == "my file (1).jpg"
+
+    def test_underscore_prefix(self):
+        assert sanitize_media_filename("_hidden.png") == "_hidden.png"
+
+    # ---- Path traversal stripping ------------------------------------------
+
+    def test_dotdot_slash_stripped(self):
+        assert sanitize_media_filename("../../evil.jpg") == "evil.jpg"
+
+    def test_path_separators_removed(self):
+        result = sanitize_media_filename("path/to/file.jpg")
+        assert result == "pathtofile.jpg"
+
+    def test_backslash_separators_removed(self):
+        result = sanitize_media_filename("path\\to\\file.jpg")
+        assert result == "pathtofile.jpg"
+
+    def test_mixed_separators(self):
+        result = sanitize_media_filename("../path\\..\\file.jpg")
+        assert "/" not in result
+        assert "\\" not in result
+        assert ".." not in result
+        assert result.endswith("file.jpg")
+
+    def test_deep_traversal(self):
+        """../../../etc/passwd.jpg has separators removed then .. removed."""
+        result = sanitize_media_filename("../../../etc/passwd.jpg")
+        assert ".." not in result
+        assert "/" not in result
+        # After removing / -> "......etcpasswd.jpg", then removing .. -> "etcpasswd.jpg"
+        assert result == "etcpasswd.jpg"
+
+    # ---- Null byte stripping -----------------------------------------------
+
+    def test_null_byte_removed(self):
+        assert sanitize_media_filename("image\0.jpg") == "image.jpg"
+
+    # ---- The ./. bypass (bug we fixed) -------------------------------------
+
+    def test_dot_slash_dot_returns_unnamed(self):
+        """./. should become unnamed after sanitisation."""
+        result = sanitize_media_filename("./.")
+        assert result == "unnamed"
+
+    # ---- Empty / degenerate inputs -----------------------------------------
+
+    def test_empty_string(self):
+        assert sanitize_media_filename("") == "unnamed"
+
+    def test_whitespace_only(self):
+        assert sanitize_media_filename("   ") == "unnamed"
+
+    def test_single_dot(self):
+        assert sanitize_media_filename(".") == "unnamed"
+
+    def test_double_dot(self):
+        assert sanitize_media_filename("..") == "unnamed"
+
+    def test_single_slash(self):
+        assert sanitize_media_filename("/") == "unnamed"
+
+    def test_dot_dot_slash(self):
+        assert sanitize_media_filename("../") == "unnamed"
+
+    def test_multiple_slashes(self):
+        assert sanitize_media_filename("////") == "unnamed"
+
+    def test_only_backslashes(self):
+        assert sanitize_media_filename("\\\\\\\\") == "unnamed"
+
+    def test_dots_and_slashes_combo(self):
+        """Various combinations of dots and slashes should all become unnamed."""
+        assert sanitize_media_filename("././..") == "unnamed"
+        assert sanitize_media_filename("../..") == "unnamed"


### PR DESCRIPTION
## Summary

- **Security fix**: `store_media_file` now validates all inputs — file paths restricted to media MIME types (image/audio/video), URLs checked for SSRF (scheme + DNS + private IP blocking), filenames sanitized against path traversal
- **`delete_media_file` fix**: Replaced `os.remove()` with `col.media.trash_files()` — files go to Anki's trash (recoverable), media DB updated, deletions propagate on sync
- **New config options**: `media_import_dir`, `media_allowed_types`, `media_allowed_hosts` for optional hardening
- **CI**: Bumped GitHub Actions to Node.js 24-compatible versions

Thanks to **[Hideaki Takahashi](https://github.com/Koukyosyumei)** (Columbia University) for responsibly disclosing the vulnerability.

## Test plan

- [ ] `pytest tests/unit/test_media_validators.py -v` — 90 unit tests for validators
- [ ] `make e2e` — full E2E cycle (239 passed + 2 skipped on local)
- [ ] Verify path traversal blocked: `store_media_file` with `path="/etc/passwd"` returns error
- [ ] Verify SSRF blocked: `store_media_file` with `url="file:///etc/passwd"` returns error
- [ ] Verify legitimate base64 store still works
- [ ] Verify `delete_media_file` response mentions "trash"
- [ ] Install `.ankiaddon` in Anki, check media tools work manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)