### PR TITLE
feat: stateless HTTP transport (align with MCP 2026-07-28 RC)

### DIFF
--- a/anki_mcp_server/config.json
+++ b/anki_mcp_server/config.json
@@ -4,7 +4,7 @@
   "http_host": "127.0.0.1",
   "http_path": "",
   "cors_origins": [],
-  "cors_expose_headers": ["mcp-session-id", "mcp-protocol-version"],
+  "cors_expose_headers": ["mcp-protocol-version"],
   "disabled_tools": [],
   "media_import_dir": "",
   "media_allowed_types": [],

--- a/anki_mcp_server/config.py
+++ b/anki_mcp_server/config.py
@@ -31,9 +31,8 @@ class Config:
     cors_origins: List[str] = field(default_factory=list)
 
     # CORS expose headers (headers browser JavaScript can read from responses)
-    # MCP protocol requires session ID header to be readable
     cors_expose_headers: List[str] = field(
-        default_factory=lambda: ["mcp-session-id", "mcp-protocol-version"]
+        default_factory=lambda: ["mcp-protocol-version"]
     )
 
     # Tool filtering (list of tool names or "tool:action" to disable)

--- a/anki_mcp_server/mcp_server.py
+++ b/anki_mcp_server/mcp_server.py
@@ -190,6 +190,7 @@ class McpServer:
                 sizes=["any"],
             )],
             streamable_http_path=streamable_path,
+            stateless_http=True,
             transport_security=security_settings,
         )
 


### PR DESCRIPTION
## Summary

- Flip `FastMCP(stateless_http=True)` so the server no longer emits or requires the `mcp-session-id` header
- Drop the now-dead `mcp-session-id` entry from the `cors_expose_headers` default

Closes #42.

## Why

The MCP protocol's upcoming **2026-07-28 release candidate** ([modelcontextprotocol/modelcontextprotocol#2750](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2750)) makes the protocol stateless by design:

- **SEP-2575** "Make MCP Stateless" — removes the `initialize`/`initialized` handshake
- **SEP-2567** "Sessionless MCP via Explicit State Handles" — removes the `Mcp-Session-Id` header
- Any request can land on any server instance

Passing `stateless_http=True` is the closest forward-compatible posture available in today's Python SDK (which has not yet adopted 2026-07-28). It also unblocks MCP clients that don't manage session-id headers — the original AnkiWeb report at #42 cited opencode's "remote" transport, but it's a class of clients that will grow as the protocol shifts.

## Regression analysis

Verified zero impact on the multi-session correctness fix from #21 / #31:

- `request_id` is a per-call UUID generated in `mcp_server.py:147`, completely orthogonal to `mcp-session-id`
- QueueBridge's `_pending` dict routes by `request_id`; the layer is unaffected by the SDK's session-tracking changes
- Stateless mode strictly *increases* per-request isolation (fresh transport per request) — the 29-concurrent-session workload validated in #21 behaves identically or better
- Transport `terminate()` runs *after* response delivery via sequential `await` in `streamable_http_manager.py:208-211`; no cleanup race vs. pending responses
- CORS `mcp-session-id` expose becomes harmless no-op (server stops emitting the header)

## Wire-level effect

- Server no longer emits `mcp-session-id` response header
- Server no longer requires `mcp-session-id` request header
- Existing stateful clients (Claude Desktop, Claude Code, Inspector CLI) keep working — their cached session-ids are silently ignored, each request gets a fresh transport
- Clients that don't manage session-ids (opencode "remote", and anything aligned with the 2026-07-28 protocol direction) now work

## Test plan

- [x] Static analysis: independent regression check via python-pro agent — no regression vs. #21
- [x] Smoke test against installed build: `list_decks`, `find_notes`, `notes_info`, `ReadMcpResourceTool anki://system-info`, parallel concurrent calls — all clean
- [x] CI E2E suite — passing for both commits on this branch
- [ ] Browser MCP client compatibility — not tested empirically; `mcp-protocol-version` still exposed, browser clients should keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)