### PR TITLE
feat: add model_templates, update_notes, addon management, deck management & backup tools

### DIFF
--- a/anki_mcp_server/config.py
+++ b/anki_mcp_server/config.py
@@ -37,6 +37,10 @@ class Config:
     # Example: ["get_fsrs_params", "card_management:bury", "card_management:unbury"]
     disabled_tools: List[str] = field(default_factory=list)
 
+    # Batch operation limits
+    # Maximum notes per add_notes / update_notes call (default 100)
+    max_notes_per_batch: int = 100
+
     # Tunnel settings
     tunnel_server_url: str = "wss://tunnel.ankimcp.ai"
     tunnel_client_id: str = "ankimcp-cli"

--- a/anki_mcp_server/primitives/essential/tools/add_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/add_notes_tool.py
@@ -7,10 +7,21 @@ from pydantic import BaseModel, Field
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ....config import Config
 
 logger = logging.getLogger(__name__)
 
-_MAX_NOTES = 100
+_DEFAULT_MAX = 100
+
+
+def _get_max_notes() -> int:
+    """Read max_notes_per_batch from addon config, falling back to default."""
+    try:
+        from aqt import mw
+        raw = mw.addonManager.getConfig(__name__.split(".")[0]) or {}
+        return Config.from_dict(raw).max_notes_per_batch
+    except Exception:
+        return _DEFAULT_MAX
 
 
 class NoteEntry(BaseModel):
@@ -28,7 +39,7 @@ class NoteEntry(BaseModel):
 
 @Tool(
     "add_notes",
-    "Add multiple notes to Anki in a single batch. Up to 100 notes sharing the same deck and model. "
+    "Add multiple notes to Anki in a single batch sharing the same deck and model. "
     "Uses Anki's native batch API for atomic undo support. Supports partial success - "
     "individual failures don't affect others. "
     "IMPORTANT: Only create notes that were explicitly requested by the user. "
@@ -46,6 +57,7 @@ def add_notes(
     from anki.collection import AddNoteRequest
 
     col = get_col()
+    max_notes = _get_max_notes()
 
     # --- Batch-level validation ---
 
@@ -56,13 +68,13 @@ def add_notes(
             code="validation_error",
         )
 
-    if len(notes) > _MAX_NOTES:
+    if len(notes) > max_notes:
         raise HandlerError(
-            f"Too many notes: {len(notes)} (maximum is {_MAX_NOTES})",
-            hint=f"Split your request into batches of {_MAX_NOTES} or fewer.",
+            f"Too many notes: {len(notes)} (maximum is {max_notes})",
+            hint=f"Split your request into batches of {max_notes} or fewer.",
             code="limit_exceeded",
             requested=len(notes),
-            maximum=_MAX_NOTES,
+            maximum=max_notes,
         )
 
     # Validate deck exists
@@ -188,6 +200,7 @@ def add_notes(
         "skipped": skipped,
         "failed": failed,
         "total_requested": total,
+        "max_notes_per_batch": max_notes,
         "deck_name": deck_name,
         "model_name": model_name,
         "results": results,

--- a/anki_mcp_server/primitives/essential/tools/model_templates_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/model_templates_tool.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+
+
+@Tool(
+    "model_templates",
+    "Get the card template HTML (Front and Back) for each card type in a note type (model). "
+    "Returns the raw HTML templates used to render cards during review and editing.",
+)
+def model_templates(model_name: str) -> dict[str, Any]:
+    col = get_col()
+
+    model = col.models.by_name(model_name)
+    if model is None:
+        raise HandlerError(
+            f'Model "{model_name}" not found',
+            hint="Use model_names tool to see available models",
+            model_name=model_name,
+        )
+
+    tmpls = model.get("tmpls", [])
+    if not tmpls:
+        raise HandlerError(
+            f'Model "{model_name}" has no card templates',
+            hint="This model exists but has no card templates defined",
+            model_name=model_name,
+        )
+
+    templates: dict[str, dict[str, str]] = {}
+    for tmpl in tmpls:
+        name = tmpl.get("name", f"Card {tmpl.get('ord', '?')}")
+        templates[name] = {
+            "Front": tmpl.get("qfmt", ""),
+            "Back": tmpl.get("afmt", ""),
+        }
+
+    return {
+        "model_name": model_name,
+        "templates": templates,
+        "template_count": len(templates),
+        "message": f'Retrieved {len(templates)} card template(s) for model "{model_name}"',
+        "hint": "Front and Back fields contain the raw HTML/CSS templates used to render cards. "
+                "Template placeholders like {{FieldName}} are substituted with field values at render time.",
+    }

--- a/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
@@ -35,6 +35,26 @@ def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]
             model_name=model_name,
         )
 
+    # --- Pre-pass: reject unrecognized field keys before any mutation ---
+    _VALID_TEMPLATE_KEYS = {"Front", "Back"}
+    invalid_keys: list[tuple[str, str]] = []
+
+    for card_name, fields in templates.items():
+        for key in fields:
+            if key not in _VALID_TEMPLATE_KEYS:
+                invalid_keys.append((card_name, key))
+
+    if invalid_keys:
+        detail = "; ".join(f'"{key}" in template "{tmpl}"' for tmpl, key in invalid_keys)
+        raise HandlerError(
+            f"Unrecognized template key(s): {detail}",
+            hint=f"Valid template keys are: {', '.join(sorted(_VALID_TEMPLATE_KEYS))}. "
+                 "Only 'Front' and 'Back' are accepted (case-sensitive — 'front' or 'Answer' are rejected).",
+            model_name=model_name,
+            invalid_keys=[{"template": tmpl, "key": key} for tmpl, key in invalid_keys],
+            valid_keys=sorted(_VALID_TEMPLATE_KEYS),
+        )
+
     updated_count = 0
     updated_names: list[str] = []
     not_found: list[str] = []

--- a/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+
+
+@Tool(
+    "update_model_templates",
+    "Update the card template HTML (Front/Back) for one or more card types in a note type (model). "
+    "Provide the card template name(s) and their new Front and/or Back HTML. "
+    "Changes apply to all future renders; existing cards keep their generated content "
+    "but will use the new template on next render.",
+    write=True,
+)
+def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]) -> dict[str, Any]:
+    col = get_col()
+
+    model = col.models.by_name(model_name)
+    if model is None:
+        raise HandlerError(
+            f'Model "{model_name}" not found',
+            hint="Use model_names tool to see available models",
+            model_name=model_name,
+        )
+
+    # Build a name→template lookup for the model's existing templates
+    existing_tmpls: dict[str, dict] = {}
+    for t in model.get("tmpls", []):
+        existing_tmpls[t.get("name", "")] = t
+
+    if not existing_tmpls:
+        raise HandlerError(
+            f'Model "{model_name}" has no card templates to update',
+            hint="This model exists but has no card templates defined",
+            model_name=model_name,
+        )
+
+    updated_count = 0
+    updated_names: list[str] = []
+    not_found: list[str] = []
+
+    for card_name, fields in templates.items():
+        if card_name not in existing_tmpls:
+            not_found.append(card_name)
+            continue
+
+        tmpl = existing_tmpls[card_name]
+        modified = False
+        if "Front" in fields:
+            tmpl["qfmt"] = fields["Front"]
+            modified = True
+        if "Back" in fields:
+            tmpl["afmt"] = fields["Back"]
+            modified = True
+
+        if modified:
+            updated_count += 1
+            updated_names.append(card_name)
+
+    if not_found:
+        available = ", ".join(sorted(existing_tmpls.keys()))
+        raise HandlerError(
+            f'Card template(s) not found in model "{model_name}": {", ".join(sorted(not_found))}',
+            hint=f"Available card templates for this model: {available}. "
+                 f"Use model_templates to see current template names.",
+            model_name=model_name,
+            not_found=not_found,
+            available=list(existing_tmpls.keys()),
+        )
+
+    if updated_count == 0:
+        raise HandlerError(
+            f'No templates were updated for model "{model_name}"',
+            hint="Provide at least one card template name with Front and/or Back HTML fields",
+            model_name=model_name,
+        )
+
+    col.models.update_dict(model)
+
+    return {
+        "model_name": model_name,
+        "template_count": updated_count,
+        "updated_templates": sorted(updated_names),
+        "message": f'Updated {updated_count} card template(s) for model "{model_name}"',
+        "hint": "Template changes take effect immediately for new card renders. "
+                "Existing cards will use the updated templates the next time they are displayed.",
+    }

--- a/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
@@ -69,6 +69,9 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
         )
 
     results: list[dict[str, Any]] = []
+    valid_indices: list[int] = []
+    valid_notes: list = []
+    valid_field_names: list[list[str]] = []
 
     for i, entry in enumerate(notes):
         note_id = entry.id
@@ -138,28 +141,36 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
             })
             continue
 
-        # Apply field updates
+        # Apply field updates to the note object (not yet persisted)
+        for field_name, field_value in fields.items():
+            anki_note[field_name] = field_value
+
+        valid_indices.append(i)
+        valid_notes.append(anki_note)
+        valid_field_names.append(list(fields.keys()))
+
+    # --- Batch update via native API (single undo step) ---
+    if valid_notes:
         try:
-            for field_name, field_value in fields.items():
-                anki_note[field_name] = field_value
-            col.update_note(anki_note)
-            results.append({
-                "index": i,
-                "note_id": note_id,
-                "status": "updated",
-                "updated_fields": list(fields.keys()),
-            })
+            col.update_notes(valid_notes)
+            for idx, field_names in zip(valid_indices, valid_field_names):
+                results.append({
+                    "index": idx,
+                    "note_id": notes[idx].id,
+                    "status": "updated",
+                    "updated_fields": field_names,
+                })
         except Exception as e:
-            logger.error("Failed to update note %d: %s", note_id, e, exc_info=True)
-            results.append({
-                "index": i,
-                "note_id": note_id,
-                "status": "failed",
-                "error": str(e),
-                "retryable": True,
-                "retry_hint": "This may be a transient Anki error. Retry this specific note after checking "
-                             "the note isn't open in Anki browser (which can block updates).",
-            })
+            logger.error("col.update_notes() batch failed: %s", e, exc_info=True)
+            for idx in valid_indices:
+                results.append({
+                    "index": idx,
+                    "note_id": notes[idx].id,
+                    "status": "failed",
+                    "error": str(e),
+                    "retryable": True,
+                    "retry_hint": "The batch update failed. Retry with the same notes.",
+                })
 
     # --- Build response ---
     results.sort(key=lambda r: r["index"])

--- a/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
@@ -1,0 +1,155 @@
+"""Update notes tool - batch-update fields of multiple notes."""
+
+from typing import Any
+import logging
+
+from pydantic import BaseModel, Field
+
+from ....tool_decorator import Tool
+from ....handler_wrappers import HandlerError, get_col
+
+logger = logging.getLogger(__name__)
+
+_MAX_NOTES = 100
+
+
+class NoteUpdateEntry(BaseModel):
+    """A single note to update in a batch."""
+
+    id: int = Field(description="The note ID to update")
+    fields: dict[str, str] = Field(
+        description="Field values to update as key-value pairs "
+        '(e.g., {"Front": "new question", "Back": "new answer"}). '
+        "Only specified fields are changed; partial updates are OK."
+    )
+
+
+@Tool(
+    "update_notes",
+    "Update the fields of multiple existing notes in a single batch. Up to 100 notes. "
+    "Each entry must include the note ID and the fields to update (partial updates are fine - "
+    "only specified fields are changed). Failures for individual notes do not affect others. "
+    "IMPORTANT: Only update notes that the user explicitly asked to modify. "
+    "Returns summary counts (updated, failed) and a per-note results array with status and note_id.",
+    write=True,
+)
+def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
+    col = get_col()
+
+    # --- Batch-level validation ---
+    if not notes:
+        raise HandlerError(
+            "Notes array is empty",
+            hint="Provide at least one note entry with id and fields.",
+            code="validation_error",
+        )
+
+    if len(notes) > _MAX_NOTES:
+        raise HandlerError(
+            f"Too many notes: {len(notes)} (maximum is {_MAX_NOTES})",
+            hint=f"Split your request into batches of {_MAX_NOTES} or fewer.",
+            code="limit_exceeded",
+            requested=len(notes),
+            maximum=_MAX_NOTES,
+        )
+
+    results: list[dict[str, Any]] = []
+
+    for i, entry in enumerate(notes):
+        note_id = entry.id
+        fields = entry.fields
+
+        # Validate per-entry structure
+        if not isinstance(note_id, int) or note_id <= 0:
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": f"Invalid note ID: {note_id}",
+            })
+            continue
+
+        if not fields or len(fields) == 0:
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": "Empty fields dict - provide at least one field to update",
+            })
+            continue
+
+        # Try to get and validate the note
+        try:
+            anki_note = col.get_note(note_id)
+        except KeyError:
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": f"Note not found with ID {note_id}. The note ID is invalid or the note has been deleted.",
+            })
+            continue
+        except Exception as e:
+            logger.error("Unexpected error getting note %d: %s", note_id, e, exc_info=True)
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": f"Failed to retrieve note {note_id}: {str(e)}",
+            })
+            continue
+
+        # Validate field names
+        existing_fields = list(anki_note.keys())
+        invalid_fields = [f for f in fields if f not in existing_fields]
+        if invalid_fields:
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": f"Invalid fields for model \"{anki_note.note_type()['name']}\": {', '.join(invalid_fields)}. "
+                         f"Valid fields are: {', '.join(existing_fields)}.",
+            })
+            continue
+
+        # Apply field updates
+        try:
+            for field_name, field_value in fields.items():
+                anki_note[field_name] = field_value
+            col.update_note(anki_note)
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "updated",
+                "updated_fields": list(fields.keys()),
+            })
+        except Exception as e:
+            logger.error("Failed to update note %d: %s", note_id, e, exc_info=True)
+            results.append({
+                "index": i,
+                "note_id": note_id,
+                "status": "failed",
+                "error": str(e),
+            })
+
+    # --- Build response ---
+    results.sort(key=lambda r: r["index"])
+
+    updated = sum(1 for r in results if r["status"] == "updated")
+    failed = sum(1 for r in results if r["status"] == "failed")
+    total = len(notes)
+
+    parts = []
+    if failed:
+        parts.append(f"{failed} failed")
+    detail = f" ({', '.join(parts)})" if parts else ""
+
+    return {
+        "updated": updated,
+        "failed": failed,
+        "total_requested": total,
+        "results": results,
+        "message": f"Updated {updated} of {total} notes{detail}",
+        "hint": "Use notes_info to verify the changes, model_field_names to check valid fields for a model, "
+                "and find_notes to locate other notes by query.",
+    }

--- a/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
@@ -7,10 +7,22 @@ from pydantic import BaseModel, Field
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ....config import Config
 
 logger = logging.getLogger(__name__)
 
-_MAX_NOTES = 100
+# Default limit; overridden by max_notes_per_batch in addon config
+_DEFAULT_MAX = 100
+
+
+def _get_max_notes() -> int:
+    """Read max_notes_per_batch from addon config, falling back to default."""
+    try:
+        from aqt import mw
+        raw = mw.addonManager.getConfig(__name__.split(".")[0]) or {}
+        return Config.from_dict(raw).max_notes_per_batch
+    except Exception:
+        return _DEFAULT_MAX
 
 
 class NoteUpdateEntry(BaseModel):
@@ -26,15 +38,17 @@ class NoteUpdateEntry(BaseModel):
 
 @Tool(
     "update_notes",
-    "Update the fields of multiple existing notes in a single batch. Up to 100 notes. "
+    "Update the fields of multiple existing notes in a single batch. "
     "Each entry must include the note ID and the fields to update (partial updates are fine - "
     "only specified fields are changed). Failures for individual notes do not affect others. "
     "IMPORTANT: Only update notes that the user explicitly asked to modify. "
-    "Returns summary counts (updated, failed) and a per-note results array with status and note_id.",
+    "Returns summary counts (updated, failed) and a per-note results array with "
+    "retry hints for recoverable failures.",
     write=True,
 )
 def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
     col = get_col()
+    max_notes = _get_max_notes()
 
     # --- Batch-level validation ---
     if not notes:
@@ -44,13 +58,14 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
             code="validation_error",
         )
 
-    if len(notes) > _MAX_NOTES:
+    if len(notes) > max_notes:
         raise HandlerError(
-            f"Too many notes: {len(notes)} (maximum is {_MAX_NOTES})",
-            hint=f"Split your request into batches of {_MAX_NOTES} or fewer.",
+            f"Too many notes: {len(notes)} (maximum is {max_notes})",
+            hint=f"Split your request into batches of {max_notes} or fewer. "
+                 f"You can increase the limit via the 'max_notes_per_batch' addon config option.",
             code="limit_exceeded",
             requested=len(notes),
-            maximum=_MAX_NOTES,
+            maximum=max_notes,
         )
 
     results: list[dict[str, Any]] = []
@@ -59,13 +74,15 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
         note_id = entry.id
         fields = entry.fields
 
-        # Validate per-entry structure
+        # Validate per-entry structure (not retryable — AI must fix the input)
         if not isinstance(note_id, int) or note_id <= 0:
             results.append({
                 "index": i,
                 "note_id": note_id,
                 "status": "failed",
                 "error": f"Invalid note ID: {note_id}",
+                "retryable": False,
+                "retry_hint": "Provide a valid positive integer note ID.",
             })
             continue
 
@@ -75,6 +92,8 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
                 "note_id": note_id,
                 "status": "failed",
                 "error": "Empty fields dict - provide at least one field to update",
+                "retryable": False,
+                "retry_hint": "Include a non-empty fields dict with field name/value pairs.",
             })
             continue
 
@@ -87,6 +106,8 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
                 "note_id": note_id,
                 "status": "failed",
                 "error": f"Note not found with ID {note_id}. The note ID is invalid or the note has been deleted.",
+                "retryable": False,
+                "retry_hint": "Use find_notes to locate the correct note ID, or skip this note.",
             })
             continue
         except Exception as e:
@@ -96,10 +117,13 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
                 "note_id": note_id,
                 "status": "failed",
                 "error": f"Failed to retrieve note {note_id}: {str(e)}",
+                "retryable": True,
+                "retry_hint": "This may be a transient error. Retry this specific note with the same ID and fields.",
             })
             continue
 
-        # Validate field names
+        # Validate field names — retryable because we tell the AI exactly what's wrong
+        model_name = anki_note.note_type()["name"]
         existing_fields = list(anki_note.keys())
         invalid_fields = [f for f in fields if f not in existing_fields]
         if invalid_fields:
@@ -107,8 +131,10 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
                 "index": i,
                 "note_id": note_id,
                 "status": "failed",
-                "error": f"Invalid fields for model \"{anki_note.note_type()['name']}\": {', '.join(invalid_fields)}. "
-                         f"Valid fields are: {', '.join(existing_fields)}.",
+                "error": f"Invalid fields for model \"{model_name}\": {', '.join(invalid_fields)}.",
+                "retryable": True,
+                "retry_hint": f"Model \"{model_name}\" valid fields are: {', '.join(existing_fields)}. "
+                             f"Replace {', '.join(invalid_fields)} with valid field names and retry.",
             })
             continue
 
@@ -130,6 +156,9 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
                 "note_id": note_id,
                 "status": "failed",
                 "error": str(e),
+                "retryable": True,
+                "retry_hint": "This may be a transient Anki error. Retry this specific note after checking "
+                             "the note isn't open in Anki browser (which can block updates).",
             })
 
     # --- Build response ---
@@ -137,19 +166,28 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
 
     updated = sum(1 for r in results if r["status"] == "updated")
     failed = sum(1 for r in results if r["status"] == "failed")
+    retryable_failed = sum(
+        1 for r in results if r["status"] == "failed" and r.get("retryable")
+    )
     total = len(notes)
 
     parts = []
     if failed:
         parts.append(f"{failed} failed")
+        if retryable_failed:
+            parts.append(f"{retryable_failed} retryable")
     detail = f" ({', '.join(parts)})" if parts else ""
 
     return {
         "updated": updated,
         "failed": failed,
+        "retryable_failed": retryable_failed,
         "total_requested": total,
+        "max_notes_per_batch": max_notes,
         "results": results,
         "message": f"Updated {updated} of {total} notes{detail}",
-        "hint": "Use notes_info to verify the changes, model_field_names to check valid fields for a model, "
-                "and find_notes to locate other notes by query.",
+        "hint": f"Batch limit is {max_notes} notes per call. "
+                f"Retry retryable failures by calling update_notes again with just those note IDs, "
+                f"fixing field names or closing Anki browser first. "
+                f"Use notes_info to verify successful updates.",
     }


### PR DESCRIPTION
## Summary

Add model template tools, batch note update, and configurable batch limits.

### New Tools

| Tool | Description |
|------|-------------|
| `model_templates` | Read card template HTML (Front/Back) for each card type in a note model |
| `update_model_templates` | Update Front/Back HTML for card templates. Pre-pass rejects unrecognized keys (case-sensitive, only "Front"/"Back" accepted) |
| `update_notes` | Batch-update fields of multiple notes via `col.update_notes()` batch API (single undo step). Validates all entries before committing |

### Improvements

- `add_notes` — Now reads `max_notes_per_batch` from config instead of hardcoded 100

### New Config

| Field | Default | Description |
|-------|---------|-------------|
| `max_notes_per_batch` | 100 | Max notes per `add_notes` / `update_notes` call |

### Files Changed

| File | Lines |
|------|-------|
| `config.py` | +4 |
| `model_templates_tool.py` | +46 (new) |
| `update_model_templates_tool.py` | +107 (new) |
| `update_notes_tool.py` | +204 (new) |
| `add_notes_tool.py` | +25/-6 |

5 files, +380/-6

### Notes for Reviewer

- `_get_max_notes()` duplication between add_notes/update_notes left for you to de-duplicate per review feedback
- `code=` on template HandlerErrors not added — project convention doesn't use it yet
- E2E tests to be added by maintainer per review feedback