### PR TITLE
fix: prevent partial in-place mutation in update_model_templates (#47)

### DIFF
--- a/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any
 
 from ....tool_decorator import Tool
@@ -15,13 +16,19 @@ from ....handler_wrappers import HandlerError, get_col
 def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]) -> dict[str, Any]:
     col = get_col()
 
-    model = col.models.by_name(model_name)
-    if model is None:
+    cached_model = col.models.by_name(model_name)
+    if cached_model is None:
         raise HandlerError(
             f'Model "{model_name}" not found',
             hint="Use model_names tool to see available models",
             model_name=model_name,
         )
+
+    # by_name() returns a live reference to Anki's cached notetype dict.
+    # Mutate a deepcopy so the cache is never touched until update_dict()'s
+    # backend call accepts the change — if the backend rejects an invalid
+    # template, the live model is left untouched (no partial in-memory leak).
+    model = copy.deepcopy(cached_model)
 
     # Build a name→template lookup for the model's existing templates
     existing_tmpls: dict[str, dict] = {}
@@ -55,15 +62,26 @@ def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]
             valid_keys=sorted(_VALID_TEMPLATE_KEYS),
         )
 
+    # --- Pre-pass: reject unknown card-template names before any mutation ---
+    # Validate every requested name up front so a mixed valid+unknown request
+    # is rejected as a whole, never applying a partial set of updates.
+    not_found = [card_name for card_name in templates if card_name not in existing_tmpls]
+
+    if not_found:
+        available = ", ".join(sorted(existing_tmpls.keys()))
+        raise HandlerError(
+            f'Card template(s) not found in model "{model_name}": {", ".join(sorted(not_found))}',
+            hint=f"Available card templates for this model: {available}. "
+                 f"Use model_templates to see current template names.",
+            model_name=model_name,
+            not_found=not_found,
+            available=list(existing_tmpls.keys()),
+        )
+
     updated_count = 0
     updated_names: list[str] = []
-    not_found: list[str] = []
 
     for card_name, fields in templates.items():
-        if card_name not in existing_tmpls:
-            not_found.append(card_name)
-            continue
-
         tmpl = existing_tmpls[card_name]
         modified = False
         if "Front" in fields:
@@ -76,17 +94,6 @@ def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]
         if modified:
             updated_count += 1
             updated_names.append(card_name)
-
-    if not_found:
-        available = ", ".join(sorted(existing_tmpls.keys()))
-        raise HandlerError(
-            f'Card template(s) not found in model "{model_name}": {", ".join(sorted(not_found))}',
-            hint=f"Available card templates for this model: {available}. "
-                 f"Use model_templates to see current template names.",
-            model_name=model_name,
-            not_found=not_found,
-            available=list(existing_tmpls.keys()),
-        )
 
     if updated_count == 0:
         raise HandlerError(

--- a/tests/e2e/test_update_model_templates_partial_mutation.py
+++ b/tests/e2e/test_update_model_templates_partial_mutation.py
@@ -1,0 +1,145 @@
+"""Regression tests for issue #47: update_model_templates partial in-place mutation.
+
+The bug: update_model_templates validates template *keys* (Front/Back) in a
+pre-pass before mutating, but unknown card-template *names* are only detected
+inside the mutation loop. col.models.by_name() returns the LIVE cached notetype
+dict, and the loop writes tmpl["qfmt"]/tmpl["afmt"] in place. So when a single
+call mixes a VALID template name with an UNKNOWN one, the valid template is
+already mutated in the in-memory cache by the time the "Card template(s) not
+found" error is raised. col.models.update_dict() is never reached (nothing is
+written to disk), but a follow-up model_templates READ re-fetches the same
+cached dict via col.models.by_name() and sees the leaked value.
+
+These tests create a DISPOSABLE, uniquely-named model with two card templates
+and run the repro on it. A disposable model is deliberate: the leak lives in the
+in-memory cache and could later be persisted to disk by ANY unrelated successful
+save of the same notetype. Running the repro on the shared "Basic" model would
+leave its cache dirty and risk a permanent disk write if a later test does a
+successful template update on Basic. A uniquely-named model that no other test
+touches is safe to leave dirty.
+"""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool
+
+# Marker that must NEVER end up in a valid template after a FAILED mixed update.
+LEAK_MARKER = "SHOULD-NOT-PERSIST"
+
+
+def _create_two_template_model() -> tuple[str, str, str, str, str]:
+    """Create a disposable model with two card templates.
+
+    Returns:
+        (model_name, valid_card_name, unknown_card_name,
+         original_valid_front, original_valid_back)
+    """
+    uid = unique_id()
+    model_name = f"PartialMutationModel{uid}"
+    valid_card = "Card A"
+    # An unknown name guaranteed not to exist on this model.
+    unknown_card = f"NoSuchCard{uid}"
+
+    original_front = "<div class=\"front\">{{Front}}</div>"
+    original_back = "{{FrontSide}}<hr id=\"answer\">{{Back}}"
+
+    result = call_tool("create_model", {
+        "model_name": model_name,
+        "in_order_fields": ["Front", "Back"],
+        "card_templates": [
+            {"Name": valid_card, "Front": original_front, "Back": original_back},
+            {
+                "Name": "Card B",
+                "Front": "<div>{{Back}}</div>",
+                "Back": "{{FrontSide}}<hr>{{Front}}",
+            },
+        ],
+    })
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name, valid_card, unknown_card, original_front, original_back
+
+
+class TestUpdateModelTemplatesPartialMutation:
+    """Reproduces issue #47: a failed mixed update must not leak a partial write."""
+
+    def test_valid_template_not_mutated_when_paired_with_unknown_name(self):
+        """A failed mixed update (valid + unknown name) must not leak the valid write.
+
+        The call mixes a VALID template name (whose Front carries LEAK_MARKER) with
+        an UNKNOWN template name. The tool returns isError "Card template(s) not
+        found" and never calls update_dict. But on buggy code the valid template's
+        qfmt was already mutated in the cached dict, so the subsequent
+        model_templates READ (re-fetching the same cached dict) sees LEAK_MARKER.
+
+        The reproducing assertion is the final one: the valid template's Front must
+        still equal its ORIGINAL value, NOT the leaked marker. On current buggy code
+        this assertion FAILS, which is the reproduction.
+        """
+        model_name, valid_card, unknown_card, original_front, original_back = (
+            _create_two_template_model()
+        )
+
+        # Mixed update: valid name carries the marker, unknown name triggers the error.
+        result = call_tool("update_model_templates", {
+            "model_name": model_name,
+            "templates": {
+                valid_card: {"Front": LEAK_MARKER},
+                unknown_card: {"Front": "x"},
+            },
+        })
+
+        # The whole update must be rejected because of the unknown card name.
+        assert result.get("isError") is True, f"Expected an error, got: {result}"
+        assert "not found" in str(result).lower()
+
+        # Read the templates back. On buggy code the valid template's Front was
+        # mutated in place in the cache before the error was raised, so this read
+        # observes the leak.
+        after = call_tool("model_templates", {"model_name": model_name})
+        assert after.get("isError") is not True, f"Read failed: {after}"
+
+        # THE REPRODUCING ASSERTION: a rejected update must not have mutated the
+        # valid template. On current buggy code the Front reads LEAK_MARKER and
+        # this fails.
+        assert after["templates"][valid_card]["Front"] == original_front, (
+            "Partial in-place mutation leaked: the valid template's Front was "
+            "changed by an update that returned an error."
+        )
+        # Back was never touched in the request and must be untouched too.
+        assert after["templates"][valid_card]["Back"] == original_back
+
+    def test_leak_is_order_independent_unknown_name_first(self):
+        """Same leak when the UNKNOWN name is listed BEFORE the valid name.
+
+        Issue #47 states the leak is order-independent: because the mutation loop
+        mutates the valid template in place regardless of dict ordering, the result
+        is the same whether the unknown name comes first or last. This variant lists
+        the unknown name first to lock in that order-independence.
+
+        Same reproducing assertion: after the failed update, the valid template's
+        Front must equal its ORIGINAL value, not LEAK_MARKER. Fails on buggy code.
+        """
+        model_name, valid_card, unknown_card, original_front, original_back = (
+            _create_two_template_model()
+        )
+
+        result = call_tool("update_model_templates", {
+            "model_name": model_name,
+            "templates": {
+                unknown_card: {"Front": "x"},
+                valid_card: {"Front": LEAK_MARKER},
+            },
+        })
+
+        assert result.get("isError") is True, f"Expected an error, got: {result}"
+        assert "not found" in str(result).lower()
+
+        after = call_tool("model_templates", {"model_name": model_name})
+        assert after.get("isError") is not True, f"Read failed: {after}"
+
+        # THE REPRODUCING ASSERTION (order-independent variant).
+        assert after["templates"][valid_card]["Front"] == original_front, (
+            "Partial in-place mutation leaked (unknown-name-first ordering): the "
+            "valid template's Front was changed by an update that returned an error."
+        )
+        assert after["templates"][valid_card]["Back"] == original_back


### PR DESCRIPTION
Fixes #47.

## Problem

`update_model_templates` validated template **keys** (`Front`/`Back`) in a true pre-pass before mutating, but unknown card-template **names** were only detected *inside* the mutation loop. Because `col.models.by_name()` returns the **live cached notetype dict**, a call mixing a valid name with an unknown one mutated the valid template in memory before raising `Card template(s) not found`.

`col.models.update_dict()` was never reached — so nothing hit disk — but the in-memory cache stayed dirty, and a later `model_templates` read (or any unrelated successful save of that model) observed the leaked value. Reproduced by the reporter at the MCP level; order-independent.

## Fix (two layers)

1. **Name pre-pass** — reject all unknown card-template names before the mutation loop, mirroring the existing invalid-keys pre-pass. The unknown-name error message/hint/kwargs are unchanged; only its position moved (from after the loop to before it). A mixed valid+unknown request is now rejected as a whole.
2. **Deepcopy the model** — mutate a `copy.deepcopy` of the notetype instead of the live cached dict, so the cache is never touched until `update_dict()`'s backend call accepts the change. This closes the same leak *class* by construction (e.g. if the Anki backend itself rejects an invalid template on save). Verified against Anki source: `by_name()`/`get()` returns a live reference and its docstring explicitly says to copy before modifying if not calling `update_dict()`; passing a copy preserves the success path (the backend persists and the cache re-fetches fresh).

## Tests

New E2E regression file `tests/e2e/test_update_model_templates_partial_mutation.py` covering both orderings (valid+unknown and unknown+valid) on a disposable, uniquely-named model (so a leak can never dirty the shared `Basic` model). Both tests **fail on the old code** (read-back shows the leaked marker) and **pass on the fix**.

Verified locally against the headless-anki Docker container:

```
tests/e2e/test_update_model_templates_partial_mutation.py ..  (2 passed)
tests/e2e/test_model_templates.py ..........               (10 passed, no regression)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)