### PR TITLE
chore: centralize notetype deepcopy via get_model_copy_or_raise (#47 follow-up)

### DIFF
--- a/anki_mcp_server/primitives/essential/tools/_model_helpers.py
+++ b/anki_mcp_server/primitives/essential/tools/_model_helpers.py
@@ -1,0 +1,25 @@
+"""Model (notetype) helper utilities used by model-mutating tools."""
+import copy
+from typing import Any
+
+from ....handler_wrappers import HandlerError
+
+
+def get_model_copy_or_raise(col: Any, model_name: str) -> dict:
+    """Return a deepcopy of the named notetype (model), raising HandlerError if absent.
+
+    col.models.by_name() returns a live reference to Anki's cached notetype dict;
+    mutating that reference can leak partial state into the in-memory cache if the
+    update is later rejected or abandoned (see issue #47). Callers that intend to
+    mutate-then-update_dict() must work on a copy. This helper centralizes both the
+    not-found check and the defensive deepcopy so model-mutating tools never touch
+    the live cache.
+    """
+    model = col.models.by_name(model_name)
+    if model is None:
+        raise HandlerError(
+            f'Model "{model_name}" not found',
+            hint="Use model_names tool to see available models",
+            model_name=model_name,
+        )
+    return copy.deepcopy(model)

--- a/anki_mcp_server/primitives/essential/tools/update_model_styling_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_model_styling_tool.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from ....tool_decorator import Tool
-from ....handler_wrappers import HandlerError, get_col
+from ....handler_wrappers import get_col
+from ._model_helpers import get_model_copy_or_raise
 
 
 @Tool(
@@ -12,13 +13,7 @@ from ....handler_wrappers import HandlerError, get_col
 def update_model_styling(model_name: str, css: str) -> dict[str, Any]:
     col = get_col()
 
-    model = col.models.by_name(model_name)
-    if model is None:
-        raise HandlerError(
-            f'Model "{model_name}" not found',
-            hint="Model not found. Use model_names tool to see available models.",
-            model_name=model_name,
-        )
+    model = get_model_copy_or_raise(col, model_name)
 
     old_css = model.get("css", "")
     old_css_length = len(old_css)

--- a/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_model_templates_tool.py
@@ -1,8 +1,8 @@
-import copy
 from typing import Any
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ._model_helpers import get_model_copy_or_raise
 
 
 @Tool(
@@ -16,19 +16,7 @@ from ....handler_wrappers import HandlerError, get_col
 def update_model_templates(model_name: str, templates: dict[str, dict[str, str]]) -> dict[str, Any]:
     col = get_col()
 
-    cached_model = col.models.by_name(model_name)
-    if cached_model is None:
-        raise HandlerError(
-            f'Model "{model_name}" not found',
-            hint="Use model_names tool to see available models",
-            model_name=model_name,
-        )
-
-    # by_name() returns a live reference to Anki's cached notetype dict.
-    # Mutate a deepcopy so the cache is never touched until update_dict()'s
-    # backend call accepts the change — if the backend rejects an invalid
-    # template, the live model is left untouched (no partial in-memory leak).
-    model = copy.deepcopy(cached_model)
+    model = get_model_copy_or_raise(col, model_name)
 
     # Build a name→template lookup for the model's existing templates
     existing_tmpls: dict[str, dict] = {}

--- a/tests/e2e/test_update_model_styling.py
+++ b/tests/e2e/test_update_model_styling.py
@@ -1,0 +1,118 @@
+"""Tests for the update_model_styling tool.
+
+These tests create DISPOSABLE, uniquely-named models via create_model so the
+shared "Basic" model is never dirtied. Uniquely-named models that no other test
+touches are safe to leave behind without cleanup (same rationale as
+test_update_model_templates_partial_mutation.py).
+
+The round-trip test is the behavior-parity guard for the
+get_model_copy_or_raise refactor (issue #47 follow-up): the tool now mutates a
+deepcopy instead of the live cached notetype dict, so a successful update must
+still persist and be readable back via model_styling.
+"""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool, list_tools
+
+CARD_TEMPLATES = [
+    {
+        "Name": "Card 1",
+        "Front": "{{Front}}",
+        "Back": "{{FrontSide}}<hr id=\"answer\">{{Back}}",
+    },
+]
+
+
+def _create_disposable_model(css: str | None = None) -> str:
+    """Create a disposable model with a unique name, optionally with initial CSS."""
+    model_name = f"StylingModel{unique_id()}"
+    args: dict = {
+        "model_name": model_name,
+        "in_order_fields": ["Front", "Back"],
+        "card_templates": CARD_TEMPLATES,
+    }
+    if css is not None:
+        args["css"] = css
+    result = call_tool("create_model", args)
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name
+
+
+class TestUpdateModelStyling:
+    """Tests for updating the CSS styling of a note type."""
+
+    def test_tool_appears_in_tools_list(self):
+        """Both styling tools should be registered and visible."""
+        tool_names = [t["name"] for t in list_tools()]
+        assert "update_model_styling" in tool_names
+        assert "model_styling" in tool_names
+
+    def test_update_css_round_trips(self):
+        """A successful update must persist and be readable back via model_styling.
+
+        This protects the deepcopy refactor: mutating a copy instead of the live
+        cached dict must still result in a persisted, readable change.
+        """
+        uid = unique_id()
+        model_name = _create_disposable_model()
+        new_css = f".card {{ color: red; }} /* marker-{uid} */"
+
+        result = call_tool("update_model_styling", {
+            "model_name": model_name,
+            "css": new_css,
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["model_name"] == model_name
+        assert result["css_length"] == len(new_css)
+
+        # Read back: the persisted CSS must equal exactly what was set.
+        after = call_tool("model_styling", {"model_name": model_name})
+        assert after.get("isError") is not True, f"Read failed: {after}"
+        assert after["css"] == new_css
+
+    def test_update_css_info_flags(self):
+        """css_info flags should reflect the content of the new CSS."""
+        model_name = _create_disposable_model()
+        new_css = (
+            ".card { direction: rtl; text-align: right; }\n"
+            ".cloze { font-weight: bold; }"
+        )
+
+        result = call_tool("update_model_styling", {
+            "model_name": model_name,
+            "css": new_css,
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["css_info"]["has_rtl_support"] is True
+        assert result["css_info"]["has_card_styling"] is True
+        assert result["css_info"]["has_cloze_styling"] is True
+
+    def test_update_reports_old_css_length_change(self):
+        """Updating a model with existing CSS should report old length and delta."""
+        old_css = ".card { color: blue; }"
+        model_name = _create_disposable_model(css=old_css)
+        new_css = ".card { color: green; font-size: 20px; }"
+
+        result = call_tool("update_model_styling", {
+            "model_name": model_name,
+            "css": new_css,
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["old_css_length"] == len(old_css)
+        assert result["css_length"] == len(new_css)
+        assert result["css_length_change"] == len(new_css) - len(old_css)
+
+    def test_unknown_model_errors(self):
+        """update_model_styling with a non-existent model should return isError."""
+        uid = unique_id()
+        result = call_tool("update_model_styling", {
+            "model_name": f"NoSuchModel{uid}",
+            "css": ".card { color: red; }",
+        })
+
+        assert result.get("isError") is True
+        assert "not found" in str(result).lower()

--- a/tests/unit/test_model_helpers.py
+++ b/tests/unit/test_model_helpers.py
@@ -1,0 +1,205 @@
+"""Unit tests for get_model_copy_or_raise (leak-safety contract, issue #47).
+
+``col.models.by_name()`` hands back a LIVE reference to Anki's cached notetype
+dict. Mutating that reference can leak partial state into the in-memory cache if
+the subsequent update is rejected or abandoned (issue #47). The helper defends
+against this by returning a *deep* copy so callers can mutate freely without ever
+touching the live cache, and raises a standardized ``HandlerError`` when the
+model is absent.
+
+These are pure-logic tests: no Docker, no running Anki. A hand-rolled fake
+``col`` stands in for the collection. The import path resolves without Anki
+because ``handler_wrappers`` imports ``aqt`` only lazily (inside ``_get_mw``),
+not at module top -- so importing ``_model_helpers`` (which imports only
+``copy``, ``typing`` and ``HandlerError``) never reaches Anki. The vendored
+pydantic + ``aqt``/``primitives`` stubbing that lets ``anki_mcp_server`` import
+at all is set up once in ``tests/unit/conftest.py``; no per-test bootstrap is
+needed here (this mirrors how ``test_destructive_tools.py`` imports addon
+modules directly). Because ``conftest.py`` stubs ``anki_mcp_server.primitives``
+as a non-package (to suppress tool auto-discovery), the helper is loaded as a
+single file via ``importlib`` rather than through the normal dotted path.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from anki_mcp_server.handler_wrappers import HandlerError
+
+# _model_helpers lives under primitives/essential/tools/, whose __init__.py runs
+# pkgutil auto-discovery (importing every tool module) — and conftest stubs
+# `anki_mcp_server.primitives` to a non-package to suppress that. So we can't
+# import the helper through the normal dotted path. Load the single file
+# directly (same technique conftest.py uses for dependency_loader.py), using the
+# full dotted name so the helper's `from ....handler_wrappers import ...`
+# relative import still resolves to the real anki_mcp_server.handler_wrappers.
+_HELPER_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "anki_mcp_server" / "primitives" / "essential" / "tools" / "_model_helpers.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "anki_mcp_server.primitives.essential.tools._model_helpers", _HELPER_PATH
+)
+_model_helpers = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_model_helpers)
+get_model_copy_or_raise = _model_helpers.get_model_copy_or_raise
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeModels:
+    """Stand-in for ``col.models`` exposing just ``by_name``.
+
+    Records each call so tests can assert the lookup name, and (when
+    configured with a dict) returns the *exact same object* on every call so a
+    test can compare the source the fake still holds against the copy the
+    helper returned.
+    """
+
+    def __init__(self, model: dict | None) -> None:
+        self._model = model
+        self.calls: list[str] = []
+
+    def by_name(self, name: str) -> dict | None:
+        self.calls.append(name)
+        return self._model
+
+
+class _FakeCol:
+    """Minimal fake collection: only ``.models`` is needed by the helper."""
+
+    def __init__(self, model: dict | None) -> None:
+        self.models = _FakeModels(model)
+
+
+def _notetype() -> dict:
+    """A nested, notetype-shaped dict for isolation testing.
+
+    Shape mirrors a real Anki notetype closely enough to exercise deep copying
+    at multiple levels: top-level scalars, a list of nested template dicts, and
+    a list of nested field dicts.
+    """
+    return {
+        "id": 1,
+        "name": "M",
+        "css": "old",
+        "tmpls": [{"name": "Card 1", "qfmt": "Q", "afmt": "A"}],
+        "flds": [{"name": "Front"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Isolation -- the core guarantee (top-down deep copy)
+# ---------------------------------------------------------------------------
+
+
+class TestIsolation:
+    """Mutating the returned copy must never touch the source object."""
+
+    def test_mutations_at_every_depth_do_not_leak_into_source(self):
+        source = _notetype()
+        col = _FakeCol(source)
+
+        result = get_model_copy_or_raise(col, "M")
+
+        # Mutate the copy at multiple depths.
+        result["css"] = "new"                      # top-level scalar
+        result["tmpls"][0]["qfmt"] = "leaked"       # nested list-element field
+        result["tmpls"].append({"name": "Card 2"})  # grow a nested list
+        result["flds"][0]["name"] = "Back"          # nested field dict
+
+        # The source the fake still holds must be byte-for-byte the original.
+        # (This is the assertion that fails if deepcopy is swapped for dict()
+        # or .copy() -- a shallow copy would let the nested mutations leak.)
+        assert source == {
+            "id": 1,
+            "name": "M",
+            "css": "old",
+            "tmpls": [{"name": "Card 1", "qfmt": "Q", "afmt": "A"}],
+            "flds": [{"name": "Front"}],
+        }
+
+        # And the fake genuinely handed back the very object we mutated against:
+        # by_name() returns the same source instance, still unchanged.
+        assert col.models.by_name("M") is source
+        assert col.models.by_name("M")["css"] == "old"
+        assert col.models.by_name("M")["tmpls"][0]["qfmt"] == "Q"
+        assert len(col.models.by_name("M")["tmpls"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Returns equal-but-not-identical (proves the copy is deep, not shallow)
+# ---------------------------------------------------------------------------
+
+
+class TestEqualButNotIdentical:
+    def test_top_level_equal_but_distinct_object(self):
+        source = _notetype()
+        col = _FakeCol(source)
+
+        result = get_model_copy_or_raise(col, "M")
+
+        assert result == source        # equal by value
+        assert result is not source    # but a different object
+
+    def test_nested_containers_are_also_copied(self):
+        source = _notetype()
+        col = _FakeCol(source)
+
+        result = get_model_copy_or_raise(col, "M")
+
+        # Depth proof: the nested list AND its dict elements are fresh objects.
+        assert result["tmpls"] is not source["tmpls"]
+        assert result["tmpls"][0] is not source["tmpls"][0]
+        assert result["flds"][0] is not source["flds"][0]
+
+
+# ---------------------------------------------------------------------------
+# 3. Not-found raises HandlerError with the standardized payload
+# ---------------------------------------------------------------------------
+
+
+class TestNotFound:
+    def test_missing_model_raises_handler_error(self):
+        col = _FakeCol(None)  # by_name returns None
+
+        with pytest.raises(HandlerError) as excinfo:
+            get_model_copy_or_raise(col, "Nope")
+
+        err = excinfo.value
+        # .message holds the human-readable text (see HandlerError.__init__).
+        assert err.message == 'Model "Nope" not found'
+        assert 'Model "Nope" not found' in str(err)
+        # .hint is the actionable suggestion (set positionally by the helper).
+        assert err.hint == "Use model_names tool to see available models"
+        # No explicit code is passed -> .code defaults to None.
+        assert err.code is None
+        # Extra kwargs land in the .data dict; the helper passes model_name=...
+        assert err.data == {"model_name": "Nope"}
+
+
+# ---------------------------------------------------------------------------
+# 4. by_name is called once with the exact requested name
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCall:
+    def test_by_name_called_once_with_given_name_on_success(self):
+        col = _FakeCol(_notetype())
+
+        get_model_copy_or_raise(col, "M")
+
+        assert col.models.calls == ["M"]
+
+    def test_by_name_called_once_with_given_name_on_missing(self):
+        col = _FakeCol(None)
+
+        with pytest.raises(HandlerError):
+            get_model_copy_or_raise(col, "Ghost")
+
+        assert col.models.calls == ["Ghost"]


### PR DESCRIPTION
Follow-up to #47 / #48. **Hygiene, not a bug fix** — `update_model_styling` was not leaking today (it follows Anki's documented `get() → mutate → update_dict()` contract, and the model cache self-heals because `update_dict()` evicts the entry before the backend call). The goal is to make "deepcopy before mutating" the **house default** so a future edit that introduces a validation gap between fetch and save can't reintroduce #47 — which is exactly how #47 happened.

## Changes

- **New `primitives/essential/tools/_model_helpers.py`** — `get_model_copy_or_raise(col, model_name)`: runs `col.models.by_name()`, raises the standardized `Model "..." not found` `HandlerError` if absent, else returns a `copy.deepcopy`. The `_` prefix keeps it out of tool auto-discovery (same convention as `_fsrs_helpers.py`).
- **`update_model_templates`** routed through the helper (drops its inline deepcopy from the #47 fix).
- **`update_model_styling`** routed through the helper — converts it from mutating the **live cached dict** to mutating a copy. Its not-found hint is standardized (message + `model_name` kwarg unchanged); its now-unused `HandlerError` import is dropped.
- **New `tests/e2e/test_update_model_styling.py`** — this tool previously had **zero** E2E coverage. Covers success round-trip (the deepcopy parity guard), `css_info` flags, old/new length reporting, and the not-found path.

## Why the helper raises (vs. returning None)
Both tools previously duplicated an identical model-not-found `HandlerError` block. Having the helper raise the standardized error deletes that duplication, so it's strictly better than relocating the deepcopy alone.

## Not migrated (intentional)
Read-only tools (`model_templates`, `model_styling`, `model_field_names`, `add_note`, `add_notes`) keep calling `by_name()` directly — deepcopying a notetype per read would be wasted work, and they never mutate. `create_model` operates on a fresh `mm.new()` dict (never cached) and is also left alone.

## Verification
Built the addon and ran against the headless-anki container:

```
tests/e2e/test_update_model_styling.py .....               (5 passed)
tests/e2e/test_model_templates.py ..........               (10 passed)
tests/e2e/test_update_model_templates_partial_mutation.py .. (2 passed)
17 passed
```

Validated against real Anki 25.09.2 pylib source (`update_dict` eviction order, `get()` docstring sanctioning the live-mutate-then-update_dict pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)