### PR TITLE
feat: add require_human_confirm() Qt dialog gate for destructive tools

### DIFF
--- a/anki_mcp_server/handler_wrappers.py
+++ b/anki_mcp_server/handler_wrappers.py
@@ -188,6 +188,52 @@ def get_mw() -> Any:
 # Use this in tool functions instead of accessing mw.col directly.
 # Raises HandlerError with helpful hint if collection not available.
 # ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# require_human_confirm - Hard human-in-the-loop gate via Qt dialog
+# ------------------------------------------------------------------------------
+# Pops up a modal Qt confirmation dialog that blocks until the human clicks
+# Yes or No. Unlike confirm=true (which the AI sets on itself), this is a
+# REAL control — the AI cannot bypass a Qt dialog.
+#
+# Use this in destructive tools (delete_decks, install_addon, etc.) as the
+# innermost gate before executing the actual operation.
+#
+# Usage:
+#   require_human_confirm("Delete Decks", f"Delete {n} decks and {m} cards?")
+# ------------------------------------------------------------------------------
+def require_human_confirm(title: str, message: str) -> None:
+    """Pop up a Qt modal confirmation dialog. AI cannot bypass.
+
+    This is a hard human-in-the-loop gate. The dialog blocks the calling
+    thread until the human physically clicks Yes or No in the Anki window.
+    If the user clicks No or closes the dialog, a HandlerError is raised.
+
+    Args:
+        title: Dialog window title (keep short, e.g. "Delete Decks")
+        message: Body text explaining the consequences
+
+    Raises:
+        HandlerError: User clicked No or dismissed the dialog
+    """
+    from PyQt6.QtWidgets import QMessageBox
+    from aqt import mw
+
+    reply = QMessageBox.question(
+        mw,
+        title,
+        message,
+        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        QMessageBox.StandardButton.No,  # default to No for safety
+    )
+    if reply != QMessageBox.StandardButton.Yes:
+        raise HandlerError(
+            "Operation cancelled by user",
+            hint="The user clicked No in the Qt confirmation dialog. "
+                 "Do not retry without asking the user again.",
+            code="user_cancelled",
+        )
+
+
 def get_col() -> Any:
     """Get Anki collection with validation.
 


### PR DESCRIPTION
## Summary

Add `require_human_confirm()` to `handler_wrappers.py` — a hard human-in-the-loop gate. AI cannot bypass this.

## Background

The project's current destructive tools only have `confirm=true` as a guard — but `confirm` is a parameter the AI passes to the tool. The AI decides whether to set it to true or false. This is a prompt-level convention, not a real security control.

In the PR #45 review, the maintainer noted:

> "there's no Qt dialog or human-in-the-loop, so it isn't a real control"

This PR addresses that. `require_human_confirm()` is a companion to #46 (destructive mechanism): `destructive=True` controls whether a tool is visible in `tools/list`, and `require_human_confirm()` controls whether a specific invocation requires physical human approval. Two layers, complementary.

## Changes

**1 file, +46 lines**

`handler_wrappers.py` — new `require_human_confirm(title: str, message: str) -> None`:

- Pops up a modal Qt `QMessageBox.question()` dialog with Yes/No buttons
- Defaults to No for safety
- Blocks the calling thread until the human physically clicks — AI cannot bypass
- User clicks No or dismisses → raises `HandlerError(code="user_cancelled")`
- User clicks Yes → returns silently, caller proceeds

## Usage

```python
from .handler_wrappers import require_human_confirm

def delete_decks(decks, ...):
    # validation...
    require_human_confirm(
        "Delete Decks",
        f"Delete {n} deck(s)? {m} cards will be permanently deleted."
    )
    # actual deletion...
```

## Notes

- This PR adds the mechanism only — no existing tools are integrated yet
- First integration will be in the upcoming deck management PR
- Qt imports are inside the function body, matching the project's existing pattern (keeps `handler_wrappers` importable in unit tests without Anki)
