### PR TITLE
feat: add model_fields tool for managing note type fields (#57)

### DIFF
--- a/.docker/config-filtered.json
+++ b/.docker/config-filtered.json
@@ -6,5 +6,8 @@
     "sync",
     "card_management:bury",
     "card_management:unbury"
+  ],
+  "enabled_destructive_tools": [
+    "model_fields:remove"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ e2e-filtered-down:
 
 # Run filtered E2E tests (assumes filtered container is running)
 e2e-filtered-test:
-	MCP_SERVER_URL=http://localhost:3142 pytest tests/e2e/test_tool_filtering_e2e.py -v
+	MCP_SERVER_URL=http://localhost:3142 pytest tests/e2e/test_tool_filtering_e2e.py tests/e2e/test_model_fields_remove.py -v
 
 # Show filtered container logs
 e2e-filtered-logs:

--- a/anki_mcp_server/primitives/essential/tools/model_fields/__init__.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/__init__.py
@@ -1,0 +1,4 @@
+"""Model fields package - imports tool to trigger @Tool registration."""
+from .model_fields_tool import model_fields
+
+__all__ = ["model_fields"]

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/__init__.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/__init__.py
@@ -1,0 +1,1 @@
+"""Model fields action implementations."""

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/_helpers.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/_helpers.py
@@ -1,0 +1,53 @@
+"""Shared field-lookup and result-shaping helpers for the model_fields tool.
+
+These helpers centralize two concerns shared by every action:
+
+1. Resolving a field dict from the SAME model copy that will be mutated. Anki's
+   ModelManager.remove_field / rename_field / reposition_field look the field up
+   by OBJECT IDENTITY (flds.remove / flds.index), so the field dict MUST come from
+   the model copy being mutated -- never a freshly reconstructed dict.
+2. Producing the not-found HandlerError with an available-field-list, matching the
+   shape used by update_model_templates_tool.py.
+"""
+from typing import Any
+
+from ......handler_wrappers import HandlerError
+
+# Advisory warning attached to schema-changing results (add / remove / rename / reposition).
+# These mutations bump the notetype schema, which forces Anki into a one-way
+# "full sync" the next time the collection syncs. This is advisory only -- the
+# addon does not change any sync behavior, it just surfaces the consequence.
+FULL_SYNC_WARNING = (
+    "This is a schema change. Anki will require a one-way full sync on the next "
+    "sync, which overwrites the collection on AnkiWeb (and other devices) with "
+    "this one. Sync your other devices first if they hold unsynced changes."
+)
+
+
+def field_names(model: dict) -> list[str]:
+    """Return the ordered list of field names for a notetype dict."""
+    return [field.get("name", "") for field in model.get("flds", [])]
+
+
+def resolve_field_or_raise(col: Any, model: dict, model_name: str, field_name: str) -> dict:
+    """Return the field dict for ``field_name`` from this exact model copy.
+
+    Raises HandlerError (with the available field list) if the field is absent.
+    The returned dict is the live element of ``model["flds"]`` so it can be passed
+    straight to ModelManager identity-based mutators.
+    """
+    # field_map(model) -> {name: (ord, FieldDict)} where FieldDict is the element
+    # of the SAME model dict we pass in -- preserving object identity.
+    field_map = col.models.field_map(model)
+    entry = field_map.get(field_name)
+    if entry is None:
+        available = ", ".join(field_names(model))
+        raise HandlerError(
+            f'Field "{field_name}" not found in model "{model_name}"',
+            hint=f"Available fields for this model: {available}. "
+                 "Use model_field_names to see current field names.",
+            model_name=model_name,
+            field_name=field_name,
+            available=field_names(model),
+        )
+    return entry[1]

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/add.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/add.py
@@ -1,0 +1,72 @@
+"""Add a field to a note type (model)."""
+from typing import Any, Optional
+
+from ......handler_wrappers import HandlerError, get_col
+from ..._model_helpers import get_model_copy_or_raise
+from ._helpers import FULL_SYNC_WARNING, field_names
+
+
+def add_field_impl(model_name: str, field_name: str, index: Optional[int] = None) -> dict[str, Any]:
+    col = get_col()
+
+    model = get_model_copy_or_raise(col, model_name)
+    existing = field_names(model)
+
+    name = field_name.strip()
+    if not name:
+        raise HandlerError(
+            "Field name must not be empty",
+            hint="Provide a non-empty field name",
+            model_name=model_name,
+        )
+
+    # --- Pre-flight validation (before touching the backend) ---
+    # Reject exact duplicates and case-insensitive collisions up front; otherwise Anki
+    # would silently rename/de-duplicate the field to keep names unique, producing a
+    # name the caller did not ask for.
+    lowered = {n.lower() for n in existing}
+    if name in existing:
+        raise HandlerError(
+            f'Field "{name}" already exists in model "{model_name}"',
+            hint="Choose a different field name, or use the rename action to change an existing field",
+            model_name=model_name,
+            field_name=name,
+            available=existing,
+        )
+    if name.lower() in lowered:
+        raise HandlerError(
+            f'Field name "{name}" collides with an existing field (case-insensitive) in model "{model_name}"',
+            hint="Anki treats field names case-insensitively for uniqueness. Choose a distinct name.",
+            model_name=model_name,
+            field_name=name,
+            available=existing,
+        )
+
+    # index is an insertion point: 0..len inclusive (len == append at the end).
+    if index is not None and not (0 <= index <= len(existing)):
+        raise HandlerError(
+            f"index {index} is out of range",
+            hint=f"index must be between 0 and {len(existing)} (inclusive) to add a field; "
+                 "omit it to append at the end",
+            model_name=model_name,
+            field_count=len(existing),
+            available=existing,
+        )
+
+    # --- Mutate the copy, then persist ---
+    new_field = col.models.new_field(name)
+    col.models.add_field(model, new_field)  # appended at the end
+    if index is not None and index != len(existing):
+        # new_field is the same object that was appended, so identity-based
+        # reposition resolves it correctly.
+        col.models.reposition_field(model, new_field, index)
+
+    col.models.update_dict(model)
+
+    return {
+        "model_name": model_name,
+        "field_name": name,
+        "fields": field_names(model),
+        "message": f'Added field "{name}" to model "{model_name}"',
+        "warning": FULL_SYNC_WARNING,
+    }

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/remove.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/remove.py
@@ -1,0 +1,36 @@
+"""Remove a field from a note type (model)."""
+from typing import Any
+
+from ......handler_wrappers import HandlerError, get_col
+from ..._model_helpers import get_model_copy_or_raise
+from ._helpers import FULL_SYNC_WARNING, field_names, resolve_field_or_raise
+
+
+def remove_field_impl(model_name: str, field_name: str) -> dict[str, Any]:
+    col = get_col()
+
+    model = get_model_copy_or_raise(col, model_name)
+
+    # --- Pre-flight validation (before touching the backend) ---
+    # Resolve from the SAME copy so the identity-based remove finds the field.
+    field = resolve_field_or_raise(col, model, model_name, field_name)
+
+    if len(model.get("flds", [])) <= 1:
+        raise HandlerError(
+            f'Cannot remove the last field of model "{model_name}"',
+            hint="A note type must keep at least one field. Add another field before removing this one.",
+            model_name=model_name,
+            field_name=field_name,
+        )
+
+    # --- Mutate the copy, then persist ---
+    col.models.remove_field(model, field)
+    col.models.update_dict(model)
+
+    return {
+        "model_name": model_name,
+        "field_name": field_name,
+        "fields": field_names(model),
+        "message": f'Removed field "{field_name}" from model "{model_name}"',
+        "warning": FULL_SYNC_WARNING,
+    }

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/rename.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/rename.py
@@ -1,0 +1,59 @@
+"""Rename a field on a note type (model)."""
+from typing import Any
+
+from ......handler_wrappers import HandlerError, get_col
+from ..._model_helpers import get_model_copy_or_raise
+from ._helpers import FULL_SYNC_WARNING, field_names, resolve_field_or_raise
+
+
+def rename_field_impl(model_name: str, field_name: str, new_name: str) -> dict[str, Any]:
+    col = get_col()
+
+    model = get_model_copy_or_raise(col, model_name)
+
+    target = new_name.strip()
+    if not target:
+        raise HandlerError(
+            "New field name must not be empty",
+            hint="Provide a non-empty new field name",
+            model_name=model_name,
+            field_name=field_name,
+        )
+
+    # --- Pre-flight validation (before touching the backend) ---
+    # Resolve from the SAME copy so the identity-based rename finds the field.
+    field = resolve_field_or_raise(col, model, model_name, field_name)
+
+    # Reject a collision with a DIFFERENT existing field (case-insensitive); otherwise
+    # Anki would silently rename/de-duplicate to keep names unique, producing a name the
+    # caller did not ask for. A pure case-change of the SAME field (e.g. "front" ->
+    # "Front") is allowed.
+    for other in field_names(model):
+        if other == field_name:
+            continue
+        if other.lower() == target.lower():
+            raise HandlerError(
+                f'Field name "{target}" collides with an existing field in model "{model_name}"',
+                hint="Anki treats field names case-insensitively for uniqueness. Choose a distinct name.",
+                model_name=model_name,
+                field_name=field_name,
+                new_name=target,
+                available=field_names(model),
+            )
+
+    # --- Mutate the copy, then persist ---
+    col.models.rename_field(model, field, target)
+    col.models.update_dict(model)
+
+    return {
+        "model_name": model_name,
+        "old_field_name": field_name,
+        "new_field_name": target,
+        "fields": field_names(model),
+        "message": f'Renamed field "{field_name}" to "{target}" in model "{model_name}"',
+        "warning": (
+            f"Card templates that reference {{{{{field_name}}}}} were NOT updated and will "
+            f"break until you fix them. Update them to {{{{{target}}}}} with the "
+            "update_model_templates tool. " + FULL_SYNC_WARNING
+        ),
+    }

--- a/anki_mcp_server/primitives/essential/tools/model_fields/actions/reposition.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/actions/reposition.py
@@ -1,0 +1,40 @@
+"""Reposition a field within a note type (model)."""
+from typing import Any
+
+from ......handler_wrappers import HandlerError, get_col
+from ..._model_helpers import get_model_copy_or_raise
+from ._helpers import FULL_SYNC_WARNING, field_names, resolve_field_or_raise
+
+
+def reposition_field_impl(model_name: str, field_name: str, index: int) -> dict[str, Any]:
+    col = get_col()
+
+    model = get_model_copy_or_raise(col, model_name)
+
+    # --- Pre-flight validation (before touching the backend) ---
+    # Resolve from the SAME copy so the identity-based reposition finds the field.
+    field = resolve_field_or_raise(col, model, model_name, field_name)
+
+    field_count = len(model.get("flds", []))
+    if not (0 <= index <= field_count - 1):
+        raise HandlerError(
+            f"index {index} is out of range",
+            hint=f"index must be between 0 and {field_count - 1} (inclusive) for this model",
+            model_name=model_name,
+            field_name=field_name,
+            field_count=field_count,
+            available=field_names(model),
+        )
+
+    # --- Mutate the copy, then persist ---
+    col.models.reposition_field(model, field, index)
+    col.models.update_dict(model)
+
+    return {
+        "model_name": model_name,
+        "field_name": field_name,
+        "index": index,
+        "fields": field_names(model),
+        "message": f'Moved field "{field_name}" to position {index} in model "{model_name}"',
+        "warning": FULL_SYNC_WARNING,
+    }

--- a/anki_mcp_server/primitives/essential/tools/model_fields/model_fields_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/model_fields/model_fields_tool.py
@@ -1,0 +1,110 @@
+"""Multi-action tool for managing fields on an existing note type (model)."""
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from .....tool_decorator import Tool
+from .....handler_wrappers import HandlerError
+
+from .actions.add import add_field_impl
+from .actions.remove import remove_field_impl
+from .actions.rename import rename_field_impl
+from .actions.reposition import reposition_field_impl
+
+_BASE_DESCRIPTION = (
+    "Manage fields on an existing note type (model). Every action changes the note "
+    "type schema, which forces a one-way full sync on the next sync -- this "
+    "overwrites the collection on AnkiWeb and your other devices."
+)
+
+
+class AddParams(BaseModel):
+    _tool_description: ClassVar[str] = (
+        "add: Add a new field to a note type. Optionally position it with a 0-based "
+        "index (default: appended at the end)."
+    )
+    action: Literal["add"]
+    model_name: str = Field(description="Name of the note type (model) to modify")
+    field_name: str = Field(description="Name of the new field to add")
+    index: Optional[int] = Field(
+        default=None,
+        description="0-based position for the new field (0..field_count, inclusive). "
+                    "Omit to append at the end.",
+    )
+
+
+class RemoveParams(BaseModel):
+    _destructive: ClassVar[bool] = True
+    _tool_description: ClassVar[str] = (
+        "remove: Permanently delete a field AND its content from every note of this "
+        "type. Irreversible bulk data loss -- the deleted content is recoverable only "
+        "from a backup. A note type must keep at least one field."
+    )
+    action: Literal["remove"]
+    model_name: str = Field(description="Name of the note type (model) to modify")
+    field_name: str = Field(description="Name of the field to remove")
+
+
+class RenameParams(BaseModel):
+    _tool_description: ClassVar[str] = (
+        "rename: Rename an existing field, preserving its content. Card templates are "
+        "NOT updated automatically -- any reference to {{OldFieldName}} renders blank "
+        "until you fix it manually with the update_model_templates tool."
+    )
+    action: Literal["rename"]
+    model_name: str = Field(description="Name of the note type (model) to modify")
+    field_name: str = Field(description="Current name of the field to rename")
+    new_name: str = Field(description="New name for the field")
+
+
+class RepositionParams(BaseModel):
+    _tool_description: ClassVar[str] = (
+        "reposition: Move an existing field to a new 0-based position, reordering the "
+        "fields of the note type."
+    )
+    action: Literal["reposition"]
+    model_name: str = Field(description="Name of the note type (model) to modify")
+    field_name: str = Field(description="Name of the field to move")
+    index: int = Field(
+        description="0-based target position for the field (0..field_count-1)",
+    )
+
+
+ModelFieldsParams = Annotated[
+    Union[AddParams, RemoveParams, RenameParams, RepositionParams],
+    Field(discriminator="action"),
+]
+
+
+@Tool(
+    "model_fields",
+    _BASE_DESCRIPTION,  # Rebuilt dynamically at MCP registration from _tool_description ClassVars
+    write=True,
+)
+def model_fields(params: ModelFieldsParams) -> dict[str, Any]:
+    match params.action:
+        case "add":
+            return add_field_impl(
+                model_name=params.model_name,
+                field_name=params.field_name,
+                index=params.index,
+            )
+        case "remove":
+            return remove_field_impl(
+                model_name=params.model_name,
+                field_name=params.field_name,
+            )
+        case "rename":
+            return rename_field_impl(
+                model_name=params.model_name,
+                field_name=params.field_name,
+                new_name=params.new_name,
+            )
+        case "reposition":
+            return reposition_field_impl(
+                model_name=params.model_name,
+                field_name=params.field_name,
+                index=params.index,
+            )
+        case _:
+            raise HandlerError(f"Unknown action: {params.action}")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -142,6 +142,44 @@ def list_prompts() -> list[dict[str, Any]]:
     return result.get("prompts", [])
 
 
+def schema_action_names(tool: dict) -> set[str]:
+    """Extract the discriminated-union action names from a tool's inputSchema.
+
+    Multi-action tools (card_management, model_fields, ...) expose a Pydantic
+    discriminated union under ``inputSchema.properties.params``. Depending on the
+    Pydantic/MCP-SDK version the action names surface in two places, and which
+    one the live schema emits is not guaranteed -- so this collects from BOTH and
+    unions them (ordering is therefore irrelevant):
+
+    * ``params.oneOf`` / ``params.anyOf`` variants, each carrying an ``action``
+      property whose ``const`` (single ``Literal``) or ``enum`` lists the value.
+    * ``params.discriminator.mapping`` keys (the literal action values).
+
+    Returns the set of action names; empty if the tool is not a multi-action
+    tool or its schema advertises no actions.
+    """
+    params_schema = (
+        tool.get("inputSchema", {})
+        .get("properties", {})
+        .get("params", {})
+    )
+
+    action_names: set[str] = set()
+
+    # Collect from oneOf/anyOf union variants.
+    for variant in params_schema.get("oneOf", []) or params_schema.get("anyOf", []):
+        action_prop = variant.get("properties", {}).get("action", {})
+        if "const" in action_prop:
+            action_names.add(action_prop["const"])
+        action_names.update(action_prop.get("enum", []))
+
+    # Collect from the discriminator mapping keys.
+    mapping = params_schema.get("discriminator", {}).get("mapping", {})
+    action_names.update(mapping.keys())
+
+    return action_names
+
+
 def get_prompt(name: str, args: dict[str, Any] | None = None) -> dict[str, Any]:
     """Get an MCP prompt by name.
 

--- a/tests/e2e/test_destructive_tools_e2e.py
+++ b/tests/e2e/test_destructive_tools_e2e.py
@@ -1,40 +1,35 @@
-"""E2E smoke test for the destructive-tools opt-in mechanism (issue #46).
+"""E2E coverage for the destructive-tools opt-in mechanism (issue #46).
 
-SCOPE / DELIBERATE LIMITATION
------------------------------
-This is a MINIMAL smoke test, not full hide/reveal coverage. The shipping
-codebase flags NOTHING as destructive yet -- the ``destructive=True`` /
-``_destructive`` machinery exists, but no real tool or action uses it. A full
-end-to-end hide/reveal test (assert a destructive tool is absent from
-``tools/list`` by default, then present after opting it in via
-``enabled_destructive_tools``) requires a real destructive tool/action to
-exist in the schema.
+SCOPE
+-----
+A real destructive action now exists: ``model_fields:remove`` (its Params model
+sets ``_destructive = True``), making it the codebase's first destructive
+action. Destructive actions are HIDDEN from ``tools/list`` unless the operator
+opts in via ``enabled_destructive_tools``. Full hide/reveal coverage is split
+across the two E2E suites:
 
-That tool does not exist yet: it arrives with the deferred deck-management
-work (the planned ``deck_management`` subpackage / ``delete_decks`` etc., see
-PR #45 group 2, which issue #46 explicitly unblocks). We intentionally do NOT
-add a fake destructive tool to the shipping code just to enable an E2E case --
-that would pollute the production tool inventory. Wiring a destructive-tool
-config into the filtered E2E compose would likewise require shipping-code
-changes, so it is intentionally NOT done here.
+  * HIDE half (this file): runs against the DEFAULT, unfiltered server (port
+    3141, ``.docker/config.json``), which does NOT set
+    ``enabled_destructive_tools``. So ``model_fields`` is present but its schema
+    must NOT advertise the ``remove`` action -- it is hidden by default.
+  * REVEAL half + behavioral remove tests: run in the filtered suite (port
+    3142, ``.docker/config-filtered.json``), which opts in via
+    ``enabled_destructive_tools: ["model_fields:remove"]``. See
+    ``test_tool_filtering_e2e.py`` (reveal assertion) and
+    ``test_model_fields_remove.py`` (behavioral remove tests).
 
-Until then:
-  * The GATING LOGIC (whole-tool + per-action hide/reveal, precedence with
-    disabled_tools, opt-in validation, the write-guard ValueError) is fully
-    covered by the unit suite: ``tests/unit/test_destructive_tools.py``.
-  * This file only asserts the SAFETY PROPERTY for the current state: adding
-    the ``enabled_destructive_tools`` config key + the gating code path did
-    NOT accidentally hide or alter the normal toolset when no tool is flagged
-    destructive.
+This file also asserts a SAFETY PROPERTY: the destructive gate must not hide or
+alter the normal (non-destructive) toolset.
 
-When a real destructive tool lands, extend this file (and likely the filtered
-compose under ``.docker/``) with the proper hide/reveal assertions.
+The GATING LOGIC (whole-tool + per-action hide/reveal, precedence with
+disabled_tools, opt-in validation, the write-guard ValueError) is unit-covered
+in ``tests/unit/test_destructive_tools.py``.
 
 Runs against the default (unfiltered) server -- typically port 3141.
 """
 from __future__ import annotations
 
-from .helpers import list_tools
+from .helpers import list_tools, schema_action_names
 
 
 # Tools that exist today and must remain visible -- the destructive gate must
@@ -93,3 +88,38 @@ class TestDestructiveGateDoesNotHideNormalTools:
             "card_management schema lost its action variants -- the per-action "
             "destructive gate may have wrongly filtered a non-destructive tool"
         )
+
+
+class TestDestructiveActionHiddenByDefault:
+    """HIDE half: model_fields:remove is destructive and hidden by default.
+
+    Runs against the default, unfiltered server (port 3141), which does NOT set
+    enabled_destructive_tools -- so the remove action must be absent from the
+    model_fields schema while the tool itself stays present.
+    """
+
+    def test_model_fields_tool_present(self):
+        """The model_fields tool itself is exposed (only the action is hidden)."""
+        tools = list_tools()
+        names = {t["name"] for t in tools}
+        assert "model_fields" in names, (
+            f"model_fields tool should be present. Found: {sorted(names)}"
+        )
+
+    def test_remove_action_hidden_but_others_present(self):
+        """remove is absent from the schema; add/rename/reposition remain."""
+        tools = list_tools()
+        mf = next((t for t in tools if t["name"] == "model_fields"), None)
+        assert mf is not None, "model_fields tool should be present"
+
+        actions = schema_action_names(mf)
+        assert actions, "Could not extract action names from model_fields schema"
+        assert "remove" not in actions, (
+            f"remove is destructive and must be hidden by default, but found "
+            f"in schema actions: {sorted(actions)}"
+        )
+        for action in ("add", "rename", "reposition"):
+            assert action in actions, (
+                f"Expected non-destructive action '{action}' to remain. "
+                f"Found: {sorted(actions)}"
+            )

--- a/tests/e2e/test_model_fields_add.py
+++ b/tests/e2e/test_model_fields_add.py
@@ -1,0 +1,185 @@
+"""Tests for the ``add`` action of the model_fields multi-action tool.
+
+Each test creates a DISPOSABLE, uniquely-named model via create_model so the
+shared "Basic" model is never dirtied. Uniquely-named models that no other test
+touches are safe to leave behind without cleanup (same rationale as
+test_update_model_styling.py / test_update_model_templates_partial_mutation.py).
+"""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool, list_tools
+
+CARD_TEMPLATES = [
+    {
+        "Name": "Card 1",
+        "Front": "{{Front}}",
+        "Back": "{{FrontSide}}<hr id=\"answer\">{{Back}}",
+    },
+]
+
+
+def _create_model(fields: list[str]) -> str:
+    """Create a disposable model with a unique name and the given fields."""
+    model_name = f"FieldsAddModel{unique_id()}"
+    result = call_tool("create_model", {
+        "model_name": model_name,
+        "in_order_fields": fields,
+        "card_templates": CARD_TEMPLATES,
+    })
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name
+
+
+def _field_names(model_name: str) -> list[str]:
+    """Return the current ordered field names via model_field_names."""
+    result = call_tool("model_field_names", {"model_name": model_name})
+    assert result.get("isError") is not True, f"model_field_names failed: {result}"
+    return result["field_names"]
+
+
+class TestModelFieldsAdd:
+    """Tests for the add action in the model_fields tool."""
+
+    def test_tool_appears_in_tools_list(self):
+        """The model_fields tool should be registered and visible."""
+        tool_names = [t["name"] for t in list_tools()]
+        assert "model_fields" in tool_names
+
+    def test_append_field_at_end(self):
+        """Without an index the new field is appended at the end."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Hint",
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["fields"] == ["Front", "Back", "Hint"]
+        # Schema change must surface the full-sync warning.
+        assert "warning" in result
+        assert "full sync" in result["warning"].lower()
+
+        # Read back: the persisted order must match.
+        assert _field_names(model_name) == ["Front", "Back", "Hint"]
+
+    def test_add_at_specific_index(self):
+        """A 0-based index inserts the field at that position."""
+        model_name = _create_model(["Front", "Back", "Extra"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Hint",
+                "index": 1,
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["fields"] == ["Front", "Hint", "Back", "Extra"]
+
+        # Read back: the persisted order must match.
+        assert _field_names(model_name) == ["Front", "Hint", "Back", "Extra"]
+
+    def test_append_at_index_equal_to_field_count(self):
+        """An index equal to the current field count appends at the end."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Hint",
+                "index": 2,
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["fields"] == ["Front", "Back", "Hint"]
+
+        # Read back: the explicitly-indexed append must land at the end.
+        assert _field_names(model_name) == ["Front", "Back", "Hint"]
+
+    def test_reject_duplicate_name(self):
+        """Adding a field whose name already exists is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Front",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "already exists" in str(result).lower()
+
+    def test_reject_case_variant_collision(self):
+        """Adding a name that collides case-insensitively is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "front",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "case" in str(result).lower()
+
+    def test_reject_out_of_range_index(self):
+        """An index beyond field_count is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Hint",
+                "index": 99,
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "out of range" in str(result).lower()
+
+    def test_reject_negative_index(self):
+        """A negative index is rejected (lower bound of the range guard)."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                "field_name": "Hint",
+                "index": -1,
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "out of range" in str(result).lower()
+
+    def test_reject_empty_name(self):
+        """A blank (whitespace-only) field name is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "add",
+                "model_name": model_name,
+                # Whitespace-only proves the server-side .strip()-then-reject
+                # path is exercised (a stronger assertion than a bare-empty value).
+                "field_name": " ",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "empty" in str(result).lower()

--- a/tests/e2e/test_model_fields_remove.py
+++ b/tests/e2e/test_model_fields_remove.py
@@ -1,0 +1,142 @@
+"""Tests for the ``remove`` action of the model_fields multi-action tool.
+
+IMPORTANT -- DESTRUCTIVE ACTION, HIDDEN BY DEFAULT
+--------------------------------------------------
+The ``remove`` action is flagged destructive (its Params model sets
+``_destructive = True``). Destructive actions are HIDDEN from the tool schema --
+the discriminated union is rebuilt without them -- UNLESS the operator opts in
+via the ``enabled_destructive_tools`` config containing ``"model_fields:remove"``.
+
+The DEFAULT e2e suite (port 3141, ``.docker/config.json``) does NOT set
+``enabled_destructive_tools``, so ``remove`` is absent from the union there and
+these tests are SKIPPED. To exercise them, run against a server whose config
+includes::
+
+    "enabled_destructive_tools": ["model_fields:remove"]
+
+The ``_require_remove_action`` autouse fixture inspects the live model_fields
+schema and skips at runtime when ``remove`` is not exposed (same runtime-skip
+style as test_update_notes.py).
+
+Each test creates a DISPOSABLE, uniquely-named model via create_model so the
+shared "Basic" model is never dirtied. Uniquely-named models that no other test
+touches are safe to leave behind without cleanup (same rationale as
+test_update_model_styling.py).
+"""
+from __future__ import annotations
+
+import pytest
+
+from .conftest import unique_id
+from .helpers import call_tool, list_tools, schema_action_names
+
+
+def _model_fields_actions() -> set[str]:
+    """Return the action names currently exposed by the model_fields schema.
+
+    Destructive actions absent from the rebuilt discriminated union (because they
+    are not opted in via enabled_destructive_tools) will not appear here.
+    """
+    tools = list_tools()
+    tool = next((t for t in tools if t["name"] == "model_fields"), None)
+    if tool is None:
+        return set()
+    return schema_action_names(tool)
+
+
+@pytest.fixture(autouse=True)
+def _require_remove_action():
+    """Skip when the destructive remove action is not opted in on this server."""
+    if "remove" not in _model_fields_actions():
+        pytest.skip(
+            "model_fields:remove is destructive and hidden from the schema unless "
+            "enabled_destructive_tools includes 'model_fields:remove' (the default "
+            "e2e suite does not opt it in)"
+        )
+
+
+def _create_model(fields: list[str]) -> str:
+    """Create a disposable model with a unique name and the given fields.
+
+    The card template references the FIRST field so the model is valid for any
+    field set -- including the single-field model used by the last-field test
+    (a template referencing a nonexistent field could generate no cards).
+    """
+    model_name = f"FieldsRemoveModel{unique_id()}"
+    first = fields[0]
+    templates = [
+        {
+            "Name": "Card 1",
+            "Front": f"{{{{{first}}}}}",
+            "Back": f"{{{{FrontSide}}}}<hr id=\"answer\">{{{{{first}}}}}",
+        },
+    ]
+    result = call_tool("create_model", {
+        "model_name": model_name,
+        "in_order_fields": fields,
+        "card_templates": templates,
+    })
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name
+
+
+def _field_names(model_name: str) -> list[str]:
+    """Return the current ordered field names via model_field_names."""
+    result = call_tool("model_field_names", {"model_name": model_name})
+    assert result.get("isError") is not True, f"model_field_names failed: {result}"
+    return result["field_names"]
+
+
+class TestModelFieldsRemove:
+    """Tests for the remove action in the model_fields tool."""
+
+    def test_remove_field(self):
+        """Removing a field drops it and persists the shortened field list."""
+        model_name = _create_model(["Front", "Back", "Extra"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "remove",
+                "model_name": model_name,
+                "field_name": "Extra",
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["fields"] == ["Front", "Back"]
+        # Schema change must surface the full-sync warning.
+        assert "warning" in result
+        assert "full sync" in result["warning"].lower()
+
+        # Read back: the persisted field list must match.
+        assert _field_names(model_name) == ["Front", "Back"]
+
+    def test_reject_field_not_found(self):
+        """Removing a field that does not exist is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "remove",
+                "model_name": model_name,
+                "field_name": "Nope",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "not found" in str(result).lower()
+
+    def test_reject_removing_last_field(self):
+        """Removing the only remaining field is rejected."""
+        model_name = _create_model(["Only"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "remove",
+                "model_name": model_name,
+                "field_name": "Only",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "last field" in str(result).lower()

--- a/tests/e2e/test_model_fields_rename.py
+++ b/tests/e2e/test_model_fields_rename.py
@@ -1,0 +1,155 @@
+"""Tests for the ``rename`` action of the model_fields multi-action tool.
+
+Each test creates a DISPOSABLE, uniquely-named model (and, where a note is
+needed, a uniquely-named deck) so shared collection state is never dirtied.
+Uniquely-named artifacts that no other test touches are safe to leave behind
+without cleanup (same rationale as test_update_model_styling.py).
+"""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool
+
+CARD_TEMPLATES = [
+    {
+        "Name": "Card 1",
+        "Front": "{{Front}}",
+        "Back": "{{FrontSide}}<hr id=\"answer\">{{Back}}",
+    },
+]
+
+
+def _create_model(fields: list[str]) -> str:
+    """Create a disposable model with a unique name and the given fields."""
+    model_name = f"FieldsRenameModel{unique_id()}"
+    result = call_tool("create_model", {
+        "model_name": model_name,
+        "in_order_fields": fields,
+        "card_templates": CARD_TEMPLATES,
+    })
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name
+
+
+def _field_names(model_name: str) -> list[str]:
+    """Return the current ordered field names via model_field_names."""
+    result = call_tool("model_field_names", {"model_name": model_name})
+    assert result.get("isError") is not True, f"model_field_names failed: {result}"
+    return result["field_names"]
+
+
+class TestModelFieldsRename:
+    """Tests for the rename action in the model_fields tool."""
+
+    def test_rename_preserves_content_and_order(self):
+        """Renaming keeps the field's content and overall order intact."""
+        uid = unique_id()
+        model_name = _create_model(["Front", "Back", "Extra"])
+        deck_name = f"E2E::FieldsRename{uid}"
+        call_tool("create_deck", {"deck_name": deck_name})
+
+        note_result = call_tool("add_note", {
+            "deck_name": deck_name,
+            "model_name": model_name,
+            "fields": {
+                "Front": f"Question {uid}",
+                "Back": f"Answer {uid}",
+                "Extra": f"Extra content {uid}",
+            },
+        })
+        assert note_result.get("isError") is not True, f"add_note failed: {note_result}"
+        note_id = note_result["note_id"]
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "rename",
+                "model_name": model_name,
+                "field_name": "Extra",
+                "new_name": "Notes",
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["old_field_name"] == "Extra"
+        assert result["new_field_name"] == "Notes"
+        assert result["fields"] == ["Front", "Back", "Notes"]
+        # The rename warning must mention that template references are NOT updated.
+        assert "warning" in result
+        assert "template" in result["warning"].lower()
+
+        # Order is preserved with the renamed field in place.
+        assert _field_names(model_name) == ["Front", "Back", "Notes"]
+
+        # Content is preserved under the new field name.
+        notes_info = call_tool("notes_info", {"notes": [note_id]})
+        fields = notes_info["notes"][0]["fields"]
+        assert "Notes" in fields
+        assert "Extra" not in fields
+        assert fields["Notes"]["value"] == f"Extra content {uid}"
+
+    def test_reject_missing_source(self):
+        """Renaming a field that does not exist is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "rename",
+                "model_name": model_name,
+                "field_name": "Nope",
+                "new_name": "Whatever",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "not found" in str(result).lower()
+
+    def test_reject_collision_with_different_field(self):
+        """Renaming onto a DIFFERENT existing field name is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "rename",
+                "model_name": model_name,
+                "field_name": "Back",
+                "new_name": "Front",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "collides" in str(result).lower()
+
+    def test_allow_pure_case_change(self):
+        """A pure case-change of the SAME field is allowed."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "rename",
+                "model_name": model_name,
+                "field_name": "Front",
+                "new_name": "front",
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["new_field_name"] == "front"
+        assert _field_names(model_name) == ["front", "Back"]
+
+    def test_reject_empty_new_name(self):
+        """A blank (whitespace-only) new name is rejected."""
+        model_name = _create_model(["Front", "Back"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "rename",
+                "model_name": model_name,
+                "field_name": "Front",
+                # Whitespace-only proves the server-side .strip()-then-reject
+                # path is exercised (a stronger assertion than a bare-empty value).
+                "new_name": " ",
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "empty" in str(result).lower()

--- a/tests/e2e/test_model_fields_reposition.py
+++ b/tests/e2e/test_model_fields_reposition.py
@@ -1,0 +1,96 @@
+"""Tests for the ``reposition`` action of the model_fields multi-action tool.
+
+Each test creates a DISPOSABLE, uniquely-named model via create_model so the
+shared "Basic" model is never dirtied. Uniquely-named models that no other test
+touches are safe to leave behind without cleanup (same rationale as
+test_update_model_styling.py / test_update_model_templates_partial_mutation.py).
+"""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool
+
+CARD_TEMPLATES = [
+    {
+        "Name": "Card 1",
+        "Front": "{{Front}}",
+        "Back": "{{FrontSide}}<hr id=\"answer\">{{Back}}",
+    },
+]
+
+
+def _create_model(fields: list[str]) -> str:
+    """Create a disposable model with a unique name and the given fields."""
+    model_name = f"FieldsRepositionModel{unique_id()}"
+    result = call_tool("create_model", {
+        "model_name": model_name,
+        "in_order_fields": fields,
+        "card_templates": CARD_TEMPLATES,
+    })
+    assert result.get("isError") is not True, f"create_model failed: {result}"
+    return model_name
+
+
+def _field_names(model_name: str) -> list[str]:
+    """Return the current ordered field names via model_field_names."""
+    result = call_tool("model_field_names", {"model_name": model_name})
+    assert result.get("isError") is not True, f"model_field_names failed: {result}"
+    return result["field_names"]
+
+
+class TestModelFieldsReposition:
+    """Tests for the reposition action in the model_fields tool."""
+
+    def test_move_field_to_new_index(self):
+        """Repositioning reorders the fields and persists the new order."""
+        model_name = _create_model(["Front", "Back", "Extra"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "reposition",
+                "model_name": model_name,
+                "field_name": "Extra",
+                "index": 0,
+            }
+        })
+
+        assert result.get("isError") is not True, f"Unexpected error: {result}"
+        assert result["fields"] == ["Extra", "Front", "Back"]
+        # Schema change must surface the full-sync warning.
+        assert "warning" in result
+        assert "full sync" in result["warning"].lower()
+
+        # Read back: the persisted order must match.
+        assert _field_names(model_name) == ["Extra", "Front", "Back"]
+
+    def test_reject_out_of_range_index(self):
+        """An index beyond the last valid position is rejected."""
+        model_name = _create_model(["Front", "Back", "Extra"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "reposition",
+                "model_name": model_name,
+                "field_name": "Front",
+                "index": 99,
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "out of range" in str(result).lower()
+
+    def test_reject_negative_index(self):
+        """A negative index is rejected (lower bound of the range guard)."""
+        model_name = _create_model(["Front", "Back", "Extra"])
+
+        result = call_tool("model_fields", {
+            "params": {
+                "action": "reposition",
+                "model_name": model_name,
+                "field_name": "Front",
+                "index": -1,
+            }
+        })
+
+        assert result.get("isError") is True
+        assert "out of range" in str(result).lower()

--- a/tests/e2e/test_tool_filtering_e2e.py
+++ b/tests/e2e/test_tool_filtering_e2e.py
@@ -1,4 +1,4 @@
-"""E2E tests for tool filtering (disabled_tools config).
+"""E2E tests for tool filtering (disabled_tools + enabled_destructive_tools).
 
 These tests run against a filtered container (port 3142) with the following
 disabled_tools config:
@@ -6,13 +6,19 @@ disabled_tools config:
     - "card_management:bury"   (single action disabled)
     - "card_management:unbury" (single action disabled)
 
+The filtered config ALSO opts a destructive action in via:
+    enabled_destructive_tools: ["model_fields:remove"]
+so the otherwise-hidden ``model_fields:remove`` action is revealed here (the
+REVEAL half of the destructive hide/reveal coverage; the HIDE half lives in
+test_destructive_tools_e2e.py against the default server).
+
 Run with:
     MCP_SERVER_URL=http://localhost:3142 pytest tests/e2e/test_tool_filtering_e2e.py -v
 """
 from __future__ import annotations
 
 from .conftest import unique_id
-from .helpers import call_tool, list_tools
+from .helpers import call_tool, list_tools, schema_action_names
 
 
 # Actions that should remain after filtering bury + unbury out
@@ -33,44 +39,6 @@ def _get_tool_by_name(tools: list[dict], name: str) -> dict | None:
         if t["name"] == name:
             return t
     return None
-
-
-def _get_schema_action_names(tool: dict) -> set[str]:
-    """Extract action names from a multi-action tool's inputSchema.
-
-    Looks in the JSON Schema for discriminated union variants. The schema
-    uses ``oneOf`` with each variant containing an ``action`` property
-    whose ``const`` or ``enum`` value identifies the action.
-    """
-    schema = tool.get("inputSchema", {})
-    action_names: set[str] = set()
-
-    # Navigate into the params property which holds the discriminated union
-    params_schema = (
-        schema.get("properties", {})
-        .get("params", {})
-    )
-
-    # Pydantic may produce oneOf or anyOf depending on version
-    variants = params_schema.get("oneOf", []) or params_schema.get("anyOf", [])
-    for variant in variants:
-        action_prop = variant.get("properties", {}).get("action", {})
-        # Pydantic uses "const" for Literal with single value
-        if "const" in action_prop:
-            action_names.add(action_prop["const"])
-        # Or "enum" with a single element
-        elif "enum" in action_prop:
-            for v in action_prop["enum"]:
-                action_names.add(v)
-
-    # Some Pydantic versions use $defs + $ref -- fallback: check the
-    # discriminator mapping if present
-    if not action_names:
-        discriminator = params_schema.get("discriminator", {})
-        mapping = discriminator.get("mapping", {})
-        action_names = set(mapping.keys())
-
-    return action_names
 
 
 class TestDisabledWholeTool:
@@ -101,7 +69,7 @@ class TestDisabledActions:
         cm_tool = _get_tool_by_name(tools, "card_management")
         assert cm_tool is not None, "card_management tool should exist"
 
-        schema_actions = _get_schema_action_names(cm_tool)
+        schema_actions = schema_action_names(cm_tool)
         assert len(schema_actions) > 0, "Could not extract action names from schema"
         assert "bury" not in schema_actions, (
             f"bury should be filtered out, but found in schema actions: {schema_actions}"
@@ -116,7 +84,7 @@ class TestDisabledActions:
         cm_tool = _get_tool_by_name(tools, "card_management")
         assert cm_tool is not None
 
-        schema_actions = _get_schema_action_names(cm_tool)
+        schema_actions = schema_action_names(cm_tool)
         for action in _EXPECTED_ENABLED_ACTIONS:
             assert action in schema_actions, (
                 f"Expected action '{action}' missing from schema. "
@@ -184,3 +152,30 @@ class TestDisabledActions:
         assert result.get("isError") is not True
         assert "suspended_count" in result
         assert result["suspended_count"] == 1
+
+
+class TestEnabledDestructiveAction:
+    """REVEAL half: opting in via enabled_destructive_tools exposes the action.
+
+    The filtered config sets enabled_destructive_tools: ["model_fields:remove"],
+    so the destructive remove action -- hidden by default -- appears in the
+    model_fields schema here.
+    """
+
+    def test_destructive_action_revealed_in_schema(self):
+        """remove appears alongside add/rename/reposition when opted in."""
+        tools = list_tools()
+        mf_tool = _get_tool_by_name(tools, "model_fields")
+        assert mf_tool is not None, "model_fields tool should exist"
+
+        schema_actions = schema_action_names(mf_tool)
+        assert len(schema_actions) > 0, "Could not extract action names from schema"
+        assert "remove" in schema_actions, (
+            f"remove should be revealed via enabled_destructive_tools, but was "
+            f"not found in schema actions: {schema_actions}"
+        )
+        for action in ("add", "rename", "reposition"):
+            assert action in schema_actions, (
+                f"Expected non-destructive action '{action}' to remain. "
+                f"Found: {schema_actions}"
+            )


### PR DESCRIPTION
Closes #57.

Adds a multi-action `model_fields` tool to add/remove/rename/reposition fields on an existing note type, following the addon's discriminated-union subpackage convention (like `card_management`, `tag_management`).

## Actions
- **add** — append a field or insert at a 0-based index
- **remove** — delete a field and its content (destructive, opt-in only)
- **rename** — rename a field, content preserved (warns templates aren't auto-updated)
- **reposition** — reorder fields

## Notes
- All four are schema changes that force a one-way full sync; each result carries an advisory `warning`, and the caveat is baked into the tool descriptions.
- Pre-flight validation: duplicate/case-collision names, last-field removal, index bounds.
- `remove` is the codebase's **first destructive action** — hidden from `tools/list` unless opted in via `enabled_destructive_tools: ["model_fields:remove"]`.
- Wires full hide/reveal E2E coverage across the default (3141) and filtered (3142) suites, and consolidates schema-action extraction into a shared `helpers.schema_action_names()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)