### PR TITLE
feat: add dry_run to update_notes; fix delete_notes ignoring max_notes_per_batch config

### DIFF
--- a/anki_mcp_server/primitives/essential/tools/delete_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/delete_notes_tool.py
@@ -3,6 +3,7 @@ import logging
 
 from ....tool_decorator import Tool
 from ....handler_wrappers import HandlerError, get_col
+from ....config import get_max_notes_per_batch
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
     "Delete notes by their IDs. This will permanently remove the notes and ALL associated cards. "
     "Requires confirmDeletion=true as a safeguard — the call will fail without it. "
     "Use dry_run=true to preview what would be deleted without actually deleting anything "
-    "(confirmDeletion is ignored during dry runs). Maximum 100 notes per request. "
+    "(confirmDeletion is ignored during dry runs). "
     "Returns deletedCount, cardsDeleted, and notFoundCount.",
     write=True,
 )
@@ -33,10 +34,12 @@ def delete_notes(
             code="validation_error",
         )
 
-    if len(notes) > 100:
+    max_notes = get_max_notes_per_batch()
+    if len(notes) > max_notes:
         raise HandlerError(
-            f"Cannot delete more than 100 notes at once for safety. Requested: {len(notes)} notes",
-            hint="Delete notes in smaller batches (maximum 100 at a time) for safety",
+            f"Cannot delete more than {max_notes} notes at once. Requested: {len(notes)} notes",
+            hint=f"Delete notes in smaller batches of {max_notes} or fewer. "
+                 f"You can increase the limit via the 'max_notes_per_batch' addon config option.",
             code="limit_exceeded",
         )
 

--- a/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
+++ b/anki_mcp_server/primitives/essential/tools/update_notes_tool.py
@@ -28,12 +28,14 @@ class NoteUpdateEntry(BaseModel):
     "Update the fields of multiple existing notes in a single batch. "
     "Each entry must include the note ID and the fields to update (partial updates are fine - "
     "only specified fields are changed). Failures for individual notes do not affect others. "
+    "Use dry_run=true to validate all entries and preview which notes would be updated "
+    "without writing any changes — useful before committing a large bulk edit. "
     "IMPORTANT: Only update notes that the user explicitly asked to modify. "
     "Returns summary counts (updated, failed) and a per-note results array with "
     "retry hints for recoverable failures.",
     write=True,
 )
-def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
+def update_notes(notes: list[NoteUpdateEntry], dry_run: bool = False) -> dict[str, Any]:
     from anki.errors import NotFoundError
 
     col = get_col()
@@ -140,6 +142,34 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
         valid_notes.append(anki_note)
         valid_field_names.append(list(fields.keys()))
 
+    # --- Dry run: validate only, skip writes ---
+    if dry_run:
+        for idx, field_names in zip(valid_indices, valid_field_names):
+            results.append({
+                "index": idx,
+                "note_id": notes[idx].id,
+                "status": "would_update",
+                "updated_fields": field_names,
+            })
+
+        results.sort(key=lambda r: r["index"])
+
+        would_update = sum(1 for r in results if r["status"] == "would_update")
+        would_fail = sum(1 for r in results if r["status"] == "failed")
+        total = len(notes)
+
+        return {
+            "dry_run": True,
+            "would_update": would_update,
+            "would_fail": would_fail,
+            "total_requested": total,
+            "max_notes_per_batch": max_notes,
+            "results": results,
+            "message": f"Dry run: would update {would_update} of {total} notes"
+                       + (f" ({would_fail} would fail)" if would_fail else ""),
+            "hint": "Set dry_run=false to perform the actual update.",
+        }
+
     # --- Batch update via native API (single undo step) ---
     if valid_notes:
         try:
@@ -181,6 +211,7 @@ def update_notes(notes: list[NoteUpdateEntry]) -> dict[str, Any]:
     detail = f" ({', '.join(parts)})" if parts else ""
 
     return {
+        "dry_run": False,
         "updated": updated,
         "failed": failed,
         "retryable_failed": retryable_failed,

--- a/tests/e2e/test_update_notes_dry_run.py
+++ b/tests/e2e/test_update_notes_dry_run.py
@@ -1,0 +1,177 @@
+"""E2E tests for update_notes dry_run parameter."""
+from __future__ import annotations
+
+from .conftest import unique_id
+from .helpers import call_tool
+
+NONEXISTENT_NOTE_ID = 99999999999999
+
+
+class TestUpdateNotesDryRun:
+    """Tests for the dry_run parameter on update_notes."""
+
+    def _create_notes(self, deck_suffix: str, count: int) -> list[int]:
+        """Create Basic notes and return their IDs."""
+        uid = unique_id()
+        deck_name = f"E2E::DryRunUpdate{deck_suffix}{uid}"
+        call_tool("create_deck", {"deck_name": deck_name})
+        notes = [
+            {"fields": {"Front": f"Orig Q{i} {uid}", "Back": f"Orig A{i} {uid}"}}
+            for i in range(count)
+        ]
+        result = call_tool("add_notes", {
+            "deck_name": deck_name,
+            "model_name": "Basic",
+            "notes": notes,
+        })
+        assert result.get("isError") is not True, f"Setup failed: {result}"
+        assert result["created"] == count
+        return [r["note_id"] for r in result["results"]]
+
+    def _delete_notes(self, note_ids: list[int]) -> None:
+        if note_ids:
+            call_tool("delete_notes", {"notes": note_ids, "confirmDeletion": True})
+
+    def _field_value(self, note_info: dict, field_name: str) -> str:
+        return note_info["fields"][field_name]["value"]
+
+    # --- dry_run=True: no writes ---
+
+    def test_dry_run_returns_preview_without_writing(self):
+        """dry_run=true should return a preview but NOT persist any field changes."""
+        note_ids = self._create_notes("Preview", 2)
+
+        try:
+            entries = [
+                {"id": note_ids[0], "fields": {"Front": "SHOULD NOT APPEAR"}},
+                {"id": note_ids[1], "fields": {"Front": "ALSO NOT APPEAR"}},
+            ]
+            result = call_tool("update_notes", {"notes": entries, "dry_run": True})
+
+            assert result.get("isError") is not True, f"Unexpected error: {result}"
+            assert result["dry_run"] is True
+            assert result["would_update"] == 2
+            assert result["would_fail"] == 0
+            assert result["total_requested"] == 2
+            assert len(result["results"]) == 2
+            for r in result["results"]:
+                assert r["status"] == "would_update"
+                assert "Front" in r["updated_fields"]
+
+            # Verify original field values are completely unchanged
+            info = call_tool("notes_info", {"notes": note_ids})
+            assert info["count"] == 2
+            for i, note in enumerate(info["notes"]):
+                assert "SHOULD NOT APPEAR" not in self._field_value(note, "Front")
+                assert "ALSO NOT APPEAR" not in self._field_value(note, "Front")
+        finally:
+            self._delete_notes(note_ids)
+
+    def test_dry_run_validates_field_names(self):
+        """dry_run=true must still validate field names and report failures."""
+        note_ids = self._create_notes("ValidateFields", 2)
+
+        try:
+            entries = [
+                {"id": note_ids[0], "fields": {"Bogus": "invalid field"}},
+                {"id": note_ids[1], "fields": {"Front": "valid field"}},
+            ]
+            result = call_tool("update_notes", {"notes": entries, "dry_run": True})
+
+            assert result.get("isError") is not True, f"Unexpected error: {result}"
+            assert result["dry_run"] is True
+            assert result["would_update"] == 1
+            assert result["would_fail"] == 1
+
+            failed = [r for r in result["results"] if r["status"] == "failed"]
+            assert len(failed) == 1
+            assert failed[0]["note_id"] == note_ids[0]
+            assert "bogus" in failed[0]["error"].lower()
+
+            # Neither note should be changed
+            info = call_tool("notes_info", {"notes": note_ids})
+            assert "valid field" not in self._field_value(info["notes"][1], "Front")
+        finally:
+            self._delete_notes(note_ids)
+
+    def test_dry_run_reports_nonexistent_notes(self):
+        """dry_run=true should report missing note IDs as failures."""
+        note_ids = self._create_notes("MissingNote", 1)
+
+        try:
+            entries = [
+                {"id": note_ids[0], "fields": {"Front": "new value"}},
+                {"id": NONEXISTENT_NOTE_ID, "fields": {"Front": "ghost"}},
+            ]
+            result = call_tool("update_notes", {"notes": entries, "dry_run": True})
+
+            assert result.get("isError") is not True, f"Unexpected error: {result}"
+            assert result["dry_run"] is True
+            assert result["would_update"] == 1
+            assert result["would_fail"] == 1
+
+            failed = [r for r in result["results"] if r["status"] == "failed"]
+            assert failed[0]["note_id"] == NONEXISTENT_NOTE_ID
+            assert "not found" in failed[0]["error"].lower()
+
+            # The valid note is still untouched
+            info = call_tool("notes_info", {"notes": note_ids})
+            assert "new value" not in self._field_value(info["notes"][0], "Front")
+        finally:
+            self._delete_notes(note_ids)
+
+    def test_dry_run_response_includes_hint_to_confirm(self):
+        """dry_run response must tell the caller how to proceed with the real update."""
+        note_ids = self._create_notes("HintCheck", 1)
+
+        try:
+            result = call_tool("update_notes", {
+                "notes": [{"id": note_ids[0], "fields": {"Front": "pending"}}],
+                "dry_run": True,
+            })
+
+            assert result.get("isError") is not True
+            assert result["dry_run"] is True
+            assert "dry_run=false" in result.get("hint", "").lower() or \
+                   "dry_run" in result.get("hint", "").lower()
+        finally:
+            self._delete_notes(note_ids)
+
+    # --- dry_run=False (default): writes proceed normally ---
+
+    def test_default_dry_run_false_still_writes(self):
+        """Omitting dry_run (or passing false) must still persist changes."""
+        note_ids = self._create_notes("RealWrite", 1)
+
+        try:
+            result = call_tool("update_notes", {
+                "notes": [{"id": note_ids[0], "fields": {"Front": "written value"}}],
+            })
+
+            assert result.get("isError") is not True
+            assert result.get("dry_run") is False
+            assert result["updated"] == 1
+
+            info = call_tool("notes_info", {"notes": note_ids})
+            assert self._field_value(info["notes"][0], "Front") == "written value"
+        finally:
+            self._delete_notes(note_ids)
+
+    def test_dry_run_false_explicit_writes(self):
+        """Explicitly passing dry_run=false must persist changes."""
+        note_ids = self._create_notes("ExplicitFalse", 1)
+
+        try:
+            result = call_tool("update_notes", {
+                "notes": [{"id": note_ids[0], "fields": {"Back": "explicit false"}}],
+                "dry_run": False,
+            })
+
+            assert result.get("isError") is not True
+            assert result.get("dry_run") is False
+            assert result["updated"] == 1
+
+            info = call_tool("notes_info", {"notes": note_ids})
+            assert self._field_value(info["notes"][0], "Back") == "explicit false"
+        finally:
+            self._delete_notes(note_ids)


### PR DESCRIPTION
## Summary

Two related consistency fixes:

### 1. `update_notes`: add `dry_run` parameter

`delete_notes` already supports `dry_run=true` to preview a destructive batch before committing. `update_notes` had no equivalent, leaving AI clients with no safety net before a large bulk field edit.

**What it does:**
- Runs the full per-entry validation pass (field-name checks, note existence, ID validity) — same as a real call
- Skips `col.update_notes()` entirely, so **no data is written**
- Returns `dry_run: true` with `would_update`/`would_fail` summary counts
- Per-note results use `status: "would_update"` instead of `"updated"`
- Existing (non-dry-run) response gains `dry_run: false` for consistency

**Example:**
```json
// Request
{ "notes": [{"id": 1234, "fields": {"Front": "new Q"}}], "dry_run": true }

// Response
{
  "dry_run": true,
  "would_update": 1,
  "would_fail": 0,
  "total_requested": 1,
  "results": [{"index": 0, "note_id": 1234, "status": "would_update", "updated_fields": ["Front"]}],
  "hint": "Set dry_run=false to perform the actual update."
}
```

### 2. `delete_notes`: respect `max_notes_per_batch` config

`delete_notes` had a hardcoded `if len(notes) > 100` ceiling. Every other batch tool — `update_notes`, `add_notes`, `notes_info` — calls `get_max_notes_per_batch()`. An operator who raises `max_notes_per_batch` in config saw the increase everywhere except delete.

**Fix:** replace the magic number with `get_max_notes_per_batch()` and update the error hint to point to the config option, matching the pattern used by the other tools.

## Tests

Added `tests/e2e/test_update_notes_dry_run.py` with 6 cases covering:
- preview returns `would_update` entries without persisting changes (verified via `notes_info`)
- field-name validation still runs and surfaces failures in dry_run
- missing note IDs reported as failures in dry_run
- hint points caller toward `dry_run=false`
- `dry_run=false` (default and explicit) still writes normally