### PR TITLE
docs: add Opencode setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,18 +143,7 @@ claude mcp add anki --transport http http://127.0.0.1:3141/
 ### Opencode
 
 ```bash
-opencode mcp add
-```
-
-In the interactive installer, choose **Remote server type** and enter `http://127.0.0.1:3141/` as the URL. No OAuth needed.
-
-Or add it directly to `~/.config/opencode/opencode.jsonc`:
-
-```jsonc
-"anki": {
-  "type": "remote",
-  "url": "http://127.0.0.1:3141/"
-}
+opencode mcp add anki --url http://127.0.0.1:3141/
 ```
 
 ### Tunnel (Remote Access)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ Requires [Node.js](https://nodejs.org/) installed. Add to your Claude Desktop co
 claude mcp add anki --transport http http://127.0.0.1:3141/
 ```
 
+### Opencode
+
+```bash
+opencode mcp add
+```
+
+In the interactive installer, choose **Remote server type** and enter `http://127.0.0.1:3141/` as the URL. No OAuth needed.
+
+Or add it directly to `~/.config/opencode/opencode.jsonc`:
+
+```jsonc
+"anki": {
+  "type": "remote",
+  "url": "http://127.0.0.1:3141/"
+}
+```
+
 ### Tunnel (Remote Access)
 
 The built-in tunnel gives your Anki collection a public HTTPS URL, so AI assistants can reach it from anywhere — no port forwarding or reverse proxy needed. The collection is relayed through a WebSocket tunnel server (`wss://tunnel.ankimcp.ai` by default). Requires an [ankimcp.ai](https://ankimcp.ai) account to log in.


### PR DESCRIPTION
Add a new Opencode subsection to the Usage section with the one-liner command to add the Anki MCP server.

```bash
opencode mcp add anki --url http://127.0.0.1:3141/
```