### PR TITLE
fix: use vendored packaging in wheel selection to survive sys.modules shadowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 
 # Anki addon build artifacts
 *.ankiaddon
+anki_mcp_server.ankiaddon.zip
 vendor/
 
 # pydantic_core download cache (runtime + test bootstrap)

--- a/anki_mcp_server/dependency_loader.py
+++ b/anki_mcp_server/dependency_loader.py
@@ -84,6 +84,66 @@ def _get_required_pydantic_core_version() -> str:
     raise RuntimeError("Could not find _COMPATIBLE_PYDANTIC_CORE_VERSION in pydantic/version.py")
 
 
+def _import_vendored_packaging():
+    """Import the ``packaging`` pieces wheel selection needs, re-resolving the
+    import fresh against ``sys.path`` (where the addon's VENDORED copy sits
+    first) even if another Anki add-on already loaded an older, incompatible
+    ``packaging`` into ``sys.modules``. This neutralises the ``sys.modules``
+    cache shadowing that causes the bug; it does NOT defend against the residual
+    (low-probability) case where another add-on has prepended an old
+    ``packaging`` AHEAD of our vendor dir on ``sys.path`` — that is out of scope.
+
+    Why this is necessary (the shadowing bug):
+
+    * Anki runs every add-on in ONE shared Python process. The addon prepends
+      its ``vendor/shared`` (clean ``packaging`` 26.2) to ``sys.path`` at
+      startup — but ``sys.path`` order only decides WHICH copy is imported when
+      a module is not already cached. The ``sys.modules`` cache wins outright.
+    * If another add-on (e.g. AnkiConnect) imported an OLD ``packaging``
+      (<= 20.9) first, ``from packaging.tags import sys_tags`` resolves to that
+      cached copy. Worse, the submodule import of ``packaging.tags`` walks the
+      cached package's ``__path__`` — NOT ``sys.path`` — so our vendor-path
+      prepend does not help.
+    * ``packaging.tags`` <= 20.9 does ``import distutils.util`` at module top.
+      ``distutils`` was removed from the stdlib in Python 3.12, so on Anki
+      25.07+ (Python 3.13) that import raises ``ModuleNotFoundError: No module
+      named 'distutils'`` — surfacing as a confusing pydantic_core "download"
+      failure even though our vendored ``packaging`` is perfectly fine.
+
+    The fix: temporarily evict any cached ``packaging`` / ``packaging.*`` from
+    ``sys.modules`` so the import below resolves fresh against ``sys.path``
+    (where the vendored copy sits first), then restore the foreign copy exactly
+    as it was so we remain a good citizen toward the add-on that loaded it. The
+    ``finally`` guarantees the restore even if the fresh import raises.
+
+    Thread-safety: this runs on the first-run download path, reached from
+    ``ensure_pydantic_core()`` / ``ensure_rpds()``, which are called at ADD-ON
+    IMPORT time (top-level in ``__init__.py``) on the main thread while Anki
+    imports the add-on — before the ``profile_did_open`` hook is registered and
+    before the background MCP server thread is spawned. There is no concurrent
+    ``sys.modules`` mutation to race against, so the evict/import/restore
+    sequence is safe without locking.
+    """
+    def _packaging_modules():
+        return [
+            name for name in sys.modules
+            if name == "packaging" or name.startswith("packaging.")
+        ]
+
+    saved = {name: sys.modules.pop(name) for name in _packaging_modules()}
+    try:
+        from packaging.tags import sys_tags
+        from packaging.utils import parse_wheel_filename, InvalidWheelFilename
+        from packaging.version import InvalidVersion
+        return sys_tags, parse_wheel_filename, InvalidWheelFilename, InvalidVersion
+    finally:
+        # Drop whatever the fresh import pulled in (our vendored copy), then put
+        # the foreign copy back so the borrowing add-on sees no change.
+        for name in _packaging_modules():
+            del sys.modules[name]
+        sys.modules.update(saved)
+
+
 def _find_wheel_url(pypi_data: dict) -> str:
     """Find the best-matching wheel URL from PyPI JSON data for this interpreter.
 
@@ -101,18 +161,22 @@ def _find_wheel_url(pypi_data: dict) -> str:
     universal2/Apple-Silicon special case (issue #52) and the ``cp313`` vs
     ``cp313t`` free-threaded confusion (issue #54).
     """
-    # ``packaging`` is imported here (function scope), not at module level, on
-    # purpose: it is only needed on the download path — exactly like the other
-    # download-only native deps (``pydantic_core``/``rpds``), which are also
-    # imported lazily inside their ensure-functions. Keeping it out of module
-    # scope means the addon stays importable on source/Nix installs that provide
-    # the addon's deps from nixpkgs but NOT ``packaging`` (those installs hit the
-    # ``import pydantic_core``/``import rpds`` fast-path or the
-    # ``_USING_SYSTEM_PACKAGES`` short-circuit and never reach wheel selection).
-    # Do NOT hoist this back to the top of the file.
-    from packaging.tags import sys_tags
-    from packaging.utils import parse_wheel_filename, InvalidWheelFilename
-    from packaging.version import InvalidVersion
+    # ``packaging`` is imported here (download path only, function scope), not at
+    # module level, on purpose: it is only needed when selecting a wheel —
+    # exactly like the other download-only native deps (``pydantic_core``/
+    # ``rpds``), which are also imported lazily inside their ensure-functions.
+    # Keeping it out of module scope means the addon stays importable on
+    # source/Nix installs that provide the addon's deps from nixpkgs but NOT
+    # ``packaging`` (those installs hit the ``import pydantic_core``/``import
+    # rpds`` fast-path or the ``_USING_SYSTEM_PACKAGES`` short-circuit and never
+    # reach wheel selection). Do NOT hoist this back to the top of the file.
+    #
+    # The import is delegated to ``_import_vendored_packaging`` so we get the
+    # VENDORED ``packaging`` even when another add-on has poisoned ``sys.modules``
+    # with an old, distutils-importing copy — see that helper's docstring.
+    sys_tags, parse_wheel_filename, InvalidWheelFilename, InvalidVersion = (
+        _import_vendored_packaging()
+    )
 
     # Map each supported tag to its priority (lower index = higher priority).
     tag_priority = {tag: index for index, tag in enumerate(sys_tags())}

--- a/tests/unit/test_dependency_loader.py
+++ b/tests/unit/test_dependency_loader.py
@@ -71,10 +71,38 @@ def _url(filename: str) -> str:
 
 def _use_tags(monkeypatch: pytest.MonkeyPatch, tags: list[Tag]) -> None:
     """Make ``_find_wheel_url`` see ``tags`` (highest-priority-first) as the
-    current interpreter's supported tags."""
-    import packaging.tags
+    current interpreter's supported tags.
 
-    monkeypatch.setattr(packaging.tags, "sys_tags", lambda: iter(tags))
+    ``_find_wheel_url`` obtains ``packaging`` via ``_import_vendored_packaging``,
+    which evicts any cached ``packaging`` from ``sys.modules`` and re-imports the
+    vendored copy fresh (to dodge a poisoned ``sys.modules`` — see
+    ``test_dependency_loader_packaging_isolation.py``). Because of that fresh
+    re-import, a monkeypatch on the ``packaging.tags`` module object would NOT be
+    seen by the function. So we stub the helper itself to return our controlled
+    ``sys_tags`` alongside the REAL ``parse_wheel_filename`` / exception types,
+    keeping filename parsing exercised end to end.
+
+    The real pieces are sourced from the SAME vendored ``packaging`` module the
+    test's ``Tag`` / ``_TAGS_*`` objects come from (the module-level import), NOT
+    a fresh re-import. ``packaging.tags.Tag.__eq__`` is gated on
+    ``isinstance(other, Tag)``, so Tag instances minted by two different copies
+    of ``packaging`` never compare equal — sourcing both sides from one module
+    keeps the priority-dict lookup in ``_find_wheel_url`` working.
+    """
+    import packaging.tags  # noqa: F401  (ensures the subtree is imported)
+    import packaging.utils
+    import packaging.version
+
+    monkeypatch.setattr(
+        _dep_loader,
+        "_import_vendored_packaging",
+        lambda: (
+            lambda: iter(tags),
+            packaging.utils.parse_wheel_filename,
+            packaging.utils.InvalidWheelFilename,
+            packaging.version.InvalidVersion,
+        ),
+    )
 
 
 # Wheel filenames from a realistic pydantic_core release (standard cp313 ABI).

--- a/tests/unit/test_dependency_loader_packaging_isolation.py
+++ b/tests/unit/test_dependency_loader_packaging_isolation.py
@@ -1,0 +1,279 @@
+"""Regression tests for ``_find_wheel_url`` against a poisoned ``packaging``.
+
+Anki runs every add-on in ONE shared Python process. The addon vendors a clean
+``packaging`` 26.2 under ``vendor/shared`` and prepends it to ``sys.path`` at
+startup. But ``sys.path`` order only decides which copy gets imported when a
+module is NOT already in ``sys.modules``. If another add-on (e.g. AnkiConnect)
+has already imported an OLD ``packaging`` (<= 20.9) into ``sys.modules`` before
+AnkiMCP hits its first-run download path, then ``from packaging.tags import
+sys_tags`` resolves to that cached old copy — the ``sys.modules`` cache wins,
+and the submodule import walks the cached package's ``__path__`` rather than
+``sys.path``, so our vendor-path prepend does NOT save us.
+
+``packaging.tags`` <= 20.9 does ``import distutils.util`` at module top.
+``distutils`` was removed from the stdlib in Python 3.12, so on Anki 25.07+
+(Python 3.13) that import raises ``ModuleNotFoundError: No module named
+'distutils'``. The net symptom is that pydantic_core's first-run "download"
+fails with a ``distutils`` error and the addon won't load — even though our own
+vendored ``packaging`` is perfectly fine and just never gets used.
+
+``_find_wheel_url`` is the ONLY place the addon imports ``packaging``, and only
+on the download path (before pydantic_core is cached), which is why the crash is
+a first-run-only event. The fix (``_import_vendored_packaging``) temporarily
+evicts any foreign ``packaging`` from ``sys.modules`` so the vendored copy is
+imported fresh, then restores the foreign copy so we stay a good citizen toward
+the add-on that loaded it.
+
+These tests load ``dependency_loader.py`` as a standalone module (same technique
+as ``test_dependency_loader.py``) so they run headless without booting Anki/Qt.
+The vendored ``packaging`` is made importable by the unit ``conftest.py``, which
+prepends ``vendor/shared`` to ``sys.path``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load dependency_loader.py as a standalone module (mirrors
+# test_dependency_loader.py) so we exercise _find_wheel_url / the new
+# _import_vendored_packaging helper without triggering anki_mcp_server/__init__.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_loader_path = _REPO_ROOT / "anki_mcp_server" / "dependency_loader.py"
+_spec = importlib.util.spec_from_file_location(
+    "_dep_loader_packaging_isolation", _loader_path
+)
+_dep_loader = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dep_loader)
+
+_find_wheel_url = _dep_loader._find_wheel_url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _packaging_module_names() -> list[str]:
+    """Every ``packaging`` / ``packaging.*`` key currently in sys.modules."""
+    return [
+        name for name in sys.modules
+        if name == "packaging" or name.startswith("packaging.")
+    ]
+
+
+def _exposes_packaging(path_entry: str) -> bool:
+    """True if ``path_entry`` makes ``import packaging`` resolvable."""
+    base = Path(path_entry)
+    return (base / "packaging" / "__init__.py").exists() or (
+        base / "packaging.py"
+    ).exists()
+
+
+def _canned_pypi_for_current_interpreter() -> tuple[dict, str]:
+    """Build PyPI JSON data containing exactly one wheel that matches THIS
+    interpreter, plus the URL that ``_find_wheel_url`` must return for it.
+
+    The wheel filename is synthesised from the highest-priority tag the REAL
+    vendored ``packaging.tags.sys_tags()`` reports, so the match is guaranteed
+    regardless of the platform/Python the test happens to run on. This must be
+    called while the vendored ``packaging`` is the resolvable copy (i.e. before
+    a test poisons or strips it).
+    """
+    import packaging.tags
+
+    top = next(iter(packaging.tags.sys_tags()))
+    filename = (
+        f"anki_mcp_isolation_pkg-1.0.0-"
+        f"{top.interpreter}-{top.abi}-{top.platform}.whl"
+    )
+    url = f"https://files.example.com/{filename}"
+    pypi_data = {
+        "info": {"version": "1.0.0"},
+        "urls": [
+            {"filename": filename, "url": url},
+            # An sdist so the function also exercises its skip path.
+            {
+                "filename": "anki_mcp_isolation_pkg-1.0.0.tar.gz",
+                "url": "https://files.example.com/anki_mcp_isolation_pkg-1.0.0.tar.gz",
+            },
+        ],
+    }
+    return pypi_data, url
+
+
+def _make_poisoned_packaging(tmp_path: Path) -> object:
+    """Create a stand-in ``packaging`` whose ``tags`` submodule raises on import.
+
+    Mimics ``packaging`` <= 20.9, whose ``packaging/tags.py`` does
+    ``import distutils.util`` at module top (and ``distutils`` is gone from the
+    stdlib on Python 3.12+). We raise the exact ``ModuleNotFoundError`` directly
+    instead of literally importing ``distutils`` so the reproduction is
+    deterministic even in environments that ship a ``distutils`` shim (e.g. via
+    setuptools).
+
+    The returned module has a ``__path__`` pointing at the on-disk fake package,
+    so when it sits in ``sys.modules`` as ``"packaging"`` the submodule import of
+    ``packaging.tags`` walks THAT path (the bug) rather than ``sys.path``.
+    """
+    pkg_dir = tmp_path / "foreign_site" / "packaging"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("__version__ = '20.9'\n")
+    (pkg_dir / "tags.py").write_text(
+        "raise ModuleNotFoundError(\"No module named 'distutils'\")\n"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "packaging",
+        pkg_dir / "__init__.py",
+        submodule_search_locations=[str(pkg_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def isolate_packaging():
+    """Snapshot and fully restore ``sys.modules`` packaging subtree + ``sys.path``.
+
+    Tests in this module deliberately poison / strip the import state, so we
+    must restore it afterwards or we leak into every other unit test.
+    """
+    saved_path = list(sys.path)
+    saved_mods = {name: sys.modules[name] for name in _packaging_module_names()}
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for name in _packaging_module_names():
+            del sys.modules[name]
+        sys.modules.update(saved_mods)
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. Regression (RED before the fix) and correct resolution (GREEN after)
+# ---------------------------------------------------------------------------
+
+def test_find_wheel_url_uses_vendored_packaging_despite_poisoned_sysmodules(
+    isolate_packaging, tmp_path: Path
+) -> None:
+    """With a foreign ``packaging`` <= 20.9 already in ``sys.modules``,
+    ``_find_wheel_url`` STILL resolves via the vendored ``packaging`` and returns
+    the correct wheel URL.
+
+    Before the fix this raises ``ModuleNotFoundError: No module named 'distutils'``
+    because ``from packaging.tags import sys_tags`` resolves to the cached old
+    copy whose ``tags`` submodule imports the now-removed ``distutils`` (RED).
+    After the fix the vendored copy is imported fresh and selection succeeds
+    (GREEN).
+    """
+    # Build canned data while the vendored packaging is still resolvable.
+    pypi_data, expected_url = _canned_pypi_for_current_interpreter()
+
+    foreign = _make_poisoned_packaging(tmp_path)
+    for name in _packaging_module_names():
+        del sys.modules[name]
+    sys.modules["packaging"] = foreign
+
+    result = _find_wheel_url(pypi_data)
+
+    assert result == expected_url
+
+
+# ---------------------------------------------------------------------------
+# 3. Good citizen: the foreign packaging is restored after the call
+# ---------------------------------------------------------------------------
+
+def test_find_wheel_url_restores_foreign_packaging(
+    isolate_packaging, tmp_path: Path
+) -> None:
+    """After ``_find_wheel_url`` runs, the foreign ``packaging`` object (and its
+    submodules) are restored to ``sys.modules`` BY IDENTITY — we never leave the
+    other add-on's import state mutated."""
+    pypi_data, expected_url = _canned_pypi_for_current_interpreter()
+
+    foreign = _make_poisoned_packaging(tmp_path)
+    # A foreign submodule the helper NEVER imports (it touches packaging.tags,
+    # packaging.utils, and packaging.version — but not packaging.specifiers), to
+    # prove the restore covers the WHOLE packaging.* subtree, not just the names
+    # the helper happens to import.
+    foreign_specifiers_submodule = type(sys)("packaging.specifiers")
+
+    for name in _packaging_module_names():
+        del sys.modules[name]
+    sys.modules["packaging"] = foreign
+    sys.modules["packaging.specifiers"] = foreign_specifiers_submodule
+
+    result = _find_wheel_url(pypi_data)
+    assert result == expected_url
+
+    # Same objects, by identity — not merely re-importable.
+    assert sys.modules.get("packaging") is foreign
+    assert sys.modules.get("packaging.specifiers") is foreign_specifiers_submodule
+
+
+# ---------------------------------------------------------------------------
+# 4. Exception safety: foreign packaging is restored even if the fresh import
+#    inside the helper raises.
+# ---------------------------------------------------------------------------
+
+def test_foreign_packaging_restored_when_vendored_import_fails(
+    isolate_packaging, tmp_path: Path
+) -> None:
+    """If the helper's fresh ``from packaging.tags import ...`` itself raises
+    (simulated by stripping every ``packaging``-exposing entry from ``sys.path``
+    so no copy is importable), the foreign ``packaging`` is STILL restored to
+    ``sys.modules`` via the helper's ``finally`` block, and the import error
+    propagates.
+
+    This guards the restore against the unhappy path — a half-evicted
+    ``sys.modules`` would silently break the very add-on whose ``packaging`` we
+    borrowed.
+    """
+    pypi_data, _expected_url = _canned_pypi_for_current_interpreter()
+
+    foreign = _make_poisoned_packaging(tmp_path)
+    for name in _packaging_module_names():
+        del sys.modules[name]
+    sys.modules["packaging"] = foreign
+
+    # Make the fresh import impossible: remove every sys.path entry that exposes
+    # a `packaging` (the vendored copy AND any site-packages copy). The foreign
+    # copy lives only in sys.modules and is evicted by the helper before import,
+    # so the import has nowhere to resolve from and raises.
+    sys.path[:] = [p for p in sys.path if not _exposes_packaging(p)]
+
+    with pytest.raises(ModuleNotFoundError):
+        _find_wheel_url(pypi_data)
+
+    # The finally path must have put the foreign copy back, by identity.
+    assert sys.modules.get("packaging") is foreign
+
+
+# ---------------------------------------------------------------------------
+# 5. No-conflict regression: with a clean sys.modules (no foreign packaging),
+#    selection still works and leaves no packaging residue behind.
+# ---------------------------------------------------------------------------
+
+def test_find_wheel_url_clean_sysmodules_no_foreign(
+    isolate_packaging,
+) -> None:
+    """With NO foreign ``packaging`` in ``sys.modules``, ``_find_wheel_url``
+    resolves via the vendored copy and returns the right URL, and the helper
+    leaves ``sys.modules`` as it found it (no ``packaging`` keys lingering)."""
+    pypi_data, expected_url = _canned_pypi_for_current_interpreter()
+
+    # Start from a genuinely clean slate: no packaging anywhere in sys.modules.
+    for name in _packaging_module_names():
+        del sys.modules[name]
+    assert _packaging_module_names() == []
+
+    result = _find_wheel_url(pypi_data)
+    assert result == expected_url
+
+    # The helper saved an empty set and restored it: nothing left behind.
+    assert _packaging_module_names() == []


### PR DESCRIPTION
## Problem

Users with the **AMBOSS** add-on installed hit a first-run crash:

```
Failed to download pydantic_core: No module named 'distutils'
```

## Root cause

Anki runs every add-on in one shared Python process. AMBOSS bundles an old `packaging` (<=20.9) and loads first (folder name sorts before numeric IDs), caching it in `sys.modules`. AnkiMCP's first-run `pydantic_core` download then does `from packaging.tags import sys_tags`, which resolves to that cached copy — the submodule import walks the cached package's `__path__`, **not** `sys.path`, so our vendor-path prepend doesn't help. `packaging.tags` <=20.9 does `import distutils.util`, and `distutils` was removed from the stdlib in Python 3.12, so on Anki 25.07+ (Python 3.13) it raises `ModuleNotFoundError` — surfacing as a confusing "download failed" even though our vendored `packaging` 26.2 is fine.

## Fix

`_import_vendored_packaging()` evicts any cached `packaging`/`packaging.*` from `sys.modules`, imports the pieces wheel selection needs fresh (resolving to our vendored copy, first on `sys.path`), then restores the foreign copy in a `finally` so the borrowing add-on is unaffected. `_find_wheel_url` is routed through it (it is the only `packaging` consumer in addon code).

## Verification

- **Reproduced in real Anki**: AMBOSS + AnkiMCP 0.23.0 -> distutils crash; this build loads cleanly with AMBOSS still installed.
- **Regression test** (`tests/unit/test_dependency_loader_packaging_isolation.py`): poisons `sys.modules` with a fake old `packaging` and asserts `_find_wheel_url` still resolves correctly — fails if the fix is reverted. Plus good-citizen restore-by-identity, exception-path restore, and no-conflict/no-residue cases. Full unit suite green; runs in CI on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)