### PR TITLE
feat: event-driven request dispatch replaces 25ms polling QTimer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Anki addon that runs an MCP server inside Anki, exposing collection operations t
                 ▼
 ┌─────────────────────────────────────────┐
 │     Qt Main Thread                      │
-│  - QTimer (25ms polling)                │
+│  - Event-driven drain (run_on_main)     │
 │  - RequestProcessor                     │
 │  - Access to mw.col (safe here)         │
 └─────────────────────────────────────────┘

--- a/anki_mcp_server/connection_manager.py
+++ b/anki_mcp_server/connection_manager.py
@@ -12,12 +12,13 @@ control methods that the UI layer calls.
 Shutdown Order (Critical):
     1. Bridge shutdown - unblocks any waiting requests
     2. MCP server stop - terminates background thread (also stops tunnel)
-    3. Request processor stop - stops main thread timer
+    3. Request processor stop - clears the waker; late drain callbacks
+       become no-ops
 
 This order ensures that:
 - Background thread's blocking queue operations are unblocked first
 - MCP server can cleanly shut down its asyncio event loop
-- Request processor timer stops after all async operations complete
+- Request processor deactivates after all async operations complete
 
 Thread Safety:
     - All methods designed to be called from Qt main thread
@@ -58,7 +59,8 @@ class ConnectionManager:
     """Manages MCP server, request processor, and tunnel lifecycle.
 
     This class orchestrates the startup and shutdown of the two-thread architecture:
-    - Main thread: RequestProcessor polls queue via QTimer
+    - Main thread: RequestProcessor drains the queue when woken (event-driven
+      dispatch via mw.taskman.run_on_main — no polling timer)
     - Background thread: McpServer runs asyncio event loop with MCP SDK + tunnel
 
     It also owns the shared tunnel subsystem instances:
@@ -92,7 +94,8 @@ class ConnectionManager:
 
     Note:
         This class must be instantiated on the Qt main thread since it creates
-        Qt components (RequestProcessor uses QTimer, TunnelLog is a QObject).
+        Qt components (TunnelLog is a QObject) and the RequestProcessor's
+        drain callbacks are scheduled onto the main thread via mw.taskman.
     """
 
     def __init__(self, config: Config) -> None:
@@ -135,15 +138,18 @@ class ConnectionManager:
         """Start MCP server (background) and request processor (main thread).
 
         Starts both components in the correct order:
-        1. Request processor on main thread (QTimer starts polling)
+        1. Request processor on main thread (registers the waker on the
+           bridge and schedules an initial drain)
         2. MCP server in background thread (asyncio event loop starts)
 
-        The request processor must start first so it's ready to handle requests
-        when the MCP server begins accepting connections.
+        The request processor must start first so its waker is registered
+        before the MCP server begins accepting connections — every request
+        enqueued from then on wakes the main thread immediately.
 
         Thread Safety:
-            Must be called from Qt main thread. The request processor uses
-            QTimer which requires the Qt event loop.
+            Must be called from Qt main thread. The request processor
+            schedules its drain callbacks via mw.taskman.run_on_main, which
+            requires the Qt event loop to be running.
 
         Idempotency:
             If already running, this method is a no-op. Use restart() to
@@ -164,9 +170,10 @@ class ConnectionManager:
         self._bridge = QueueBridge()
 
         # Start request processor on main thread
-        # This begins polling the request_queue every 25ms
+        # This registers the waker on the bridge (event-driven dispatch) and
+        # schedules an initial drain for anything already queued
         self._processor = RequestProcessor(self._bridge)
-        self._processor.start(interval_ms=25)
+        self._processor.start()
 
         # Start MCP server in background thread
         # This creates a daemon thread running asyncio event loop
@@ -180,7 +187,8 @@ class ConnectionManager:
         1. Bridge shutdown - signals shutdown and unblocks waiting requests
         2. MCP server stop - terminates background thread gracefully
            (also stops the tunnel if running)
-        3. Request processor stop - stops main thread timer
+        3. Request processor stop - clears the waker and deactivates, so
+           late drain callbacks already queued in Qt become no-ops
 
         This order is critical:
         - Bridge shutdown must happen FIRST to unblock any threads waiting
@@ -218,8 +226,8 @@ class ConnectionManager:
             self._server.stop()
             self._server = None
 
-        # 3. Stop request processor (main thread timer)
-        # This stops the QTimer so it no longer polls the request queue
+        # 3. Stop request processor (main thread consumer)
+        # This clears the waker and makes any late drain callbacks no-ops
         if self._processor:
             self._processor.stop()
             self._processor = None

--- a/anki_mcp_server/primitives/essential/tools/_sync_runner.py
+++ b/anki_mcp_server/primitives/essential/tools/_sync_runner.py
@@ -35,8 +35,9 @@ Two transports for the actual transfer:
   blocks the user from clicking Browse/Stats and crashing on the closed
   collection. ``with_progress`` still returns immediately (it shows a modeless-
   to-code dialog via ``.show()``, not ``.exec()``), so the handler returns fast
-  and QTimers -- including the queue-bridge poll and ``sync`` status polls --
-  keep firing. The registry gate is kept as belt-and-suspenders defense.
+  and the main event loop keeps delivering main-thread work -- the queue
+  bridge's ``run_on_main`` drain closures and the ``sync`` status-poll QTimers
+  both keep firing. The registry gate is kept as belt-and-suspenders defense.
 
 Concurrency safety comes from the registry's gate + single-flight, mirroring
 Anki's own ``qt/aqt/sync.py`` sequencing for the collection-closing full sync.

--- a/anki_mcp_server/queue_bridge.py
+++ b/anki_mcp_server/queue_bridge.py
@@ -6,14 +6,17 @@ MCP server) and the Qt main thread (where Anki collection access is safe).
 
 Architecture:
     - Background thread: MCP server handles protocol, puts requests in queue,
-      blocks waiting for responses
-    - Main thread: QTimer polls request queue, executes Anki operations, sends
-      responses back
+      fires the registered waker (event-driven wake-up of the main thread),
+      then blocks waiting for responses
+    - Main thread: a drain callback (scheduled by the waker via
+      mw.taskman.run_on_main) pulls requests off the queue, executes Anki
+      operations, and sends responses back. No polling — the main thread is
+      only woken when there is work to do.
 
 Thread Safety:
     - Uses Python's built-in `queue.Queue` which is thread-safe by design
     - Per-request response queues via _pending dict (protected by _pending_lock)
-    - Main thread never blocks - uses get_nowait() in QTimer callback
+    - Main thread never blocks - uses get_nowait() in the drain callback
 
 Response Routing:
     Each call to send_request() creates a private one-shot queue keyed by
@@ -22,10 +25,13 @@ Response Routing:
     multiple concurrent MCP sessions without cross-talk.
 """
 
+import logging
 import queue
 import threading
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class BridgeError(Exception):
@@ -118,11 +124,13 @@ class QueueBridge:
     Usage Pattern:
         1. Background thread (MCP server):
            - Creates ToolRequest
-           - Calls send_request() - this BLOCKS until response is ready
+           - Calls send_request() - puts the request, fires the waker (which
+             schedules a main-thread drain), then BLOCKS until the response
+             is ready
            - Returns result to MCP client
 
-        2. Main thread (QTimer callback every 25ms):
-           - Calls get_pending_request() - non-blocking
+        2. Main thread (drain callback, scheduled by the waker):
+           - Calls get_pending_request() - non-blocking, loops until empty
            - If request found, executes on Anki collection
            - Calls send_response() - unblocks waiting background thread
 
@@ -136,6 +144,15 @@ class QueueBridge:
         request_id. The main thread's send_response() looks up this queue and
         delivers the response to the correct waiting thread. This supports
         multiple concurrent MCP sessions without cross-talk.
+
+    Waker (event-driven dispatch):
+        The consumer (RequestProcessor) registers a waker via set_waker().
+        send_request() fires the waker right after enqueueing, waking the
+        main thread exactly when there is work — no polling. The bridge
+        stays Qt-free: the waker is an opaque zero-argument callable, and
+        any Qt scheduling (mw.taskman.run_on_main) lives in the caller.
+        With no waker registered, puts still succeed but nothing drains
+        the queue until a consumer registers and performs a drain.
 
     Shutdown Handling:
         - Setting _shutdown=True prevents new requests
@@ -154,9 +171,9 @@ class QueueBridge:
         ...     tool_name="list_decks",
         ...     arguments={}
         ... )
-        >>> response = bridge.send_request(request)  # Blocks until main thread responds
+        >>> response = bridge.send_request(request)  # Wakes main thread, blocks for response
         >>>
-        >>> # In main thread (QTimer callback):
+        >>> # In main thread (drain callback scheduled by the waker):
         >>> request = bridge.get_pending_request()  # Non-blocking
         >>> if request:
         ...     result = execute_on_anki(request)
@@ -175,19 +192,54 @@ class QueueBridge:
         - request_queue: shared FIFO for incoming tool requests
         - _pending: dict mapping request_id -> per-request response queue
         - _pending_lock: protects _pending and _shutdown for thread safety
+        - _waker: optional callable fired after each enqueue (see set_waker)
         """
         self.request_queue: queue.Queue[ToolRequest] = queue.Queue()
         self._pending: dict[str, queue.Queue[ToolResponse]] = {}
         self._pending_lock = threading.Lock()
         self._shutdown = False
+        self._waker: Optional[Callable[[], None]] = None
+
+    def set_waker(self, waker: Callable[[], None]) -> None:
+        """Register the waker fired after each request is enqueued.
+
+        The waker is how event-driven dispatch stays Qt-free at this layer:
+        the consumer (RequestProcessor) passes a callable that schedules a
+        drain onto the Qt main thread, and this module never imports aqt.
+
+        Args:
+            waker: Zero-argument callable invoked from send_request() right
+                after the request is put on the queue. Called from the
+                background thread — it must be thread-safe (run_on_main is).
+
+        Thread Safety:
+            Assigning a single attribute is atomic under the GIL. Typically
+            called from the Qt main thread during processor start().
+        """
+        self._waker = waker
+
+    def clear_waker(self) -> None:
+        """Deregister the waker.
+
+        After this, send_request() still enqueues requests but no longer
+        wakes anyone — same semantics as a stopped consumer. Called during
+        processor stop(); requests enqueued afterwards stay queued until a
+        consumer registers again and performs a drain.
+
+        Thread Safety:
+            Assigning a single attribute is atomic under the GIL.
+        """
+        self._waker = None
 
     def send_request(self, request: ToolRequest) -> ToolResponse:
         """Send request to main thread and wait for response.
 
         Called from background thread (MCP server) when a tool call is received.
-        This method BLOCKS until the main thread processes the request and sends
-        a response back. This is safe because it's not the Qt main thread that
-        blocks.
+        After enqueueing, the registered waker (if any) is fired so the main
+        thread schedules a drain immediately — this is the event-driven
+        replacement for the old polling timer. This method then BLOCKS until
+        the main thread processes the request and sends a response back. This
+        is safe because it's not the Qt main thread that blocks.
 
         Each call creates a private one-shot queue keyed by request_id. This
         ensures that with multiple concurrent sessions, each thread receives
@@ -218,6 +270,28 @@ class QueueBridge:
             self._pending[request.request_id] = response_q
 
         self.request_queue.put(request)
+
+        # Wake the main-thread consumer (event-driven dispatch). Ordering is
+        # critical: put FIRST, then wake, then block — so the drain scheduled
+        # by the wake is guaranteed to see the request. Snapshot the attribute
+        # so a concurrent clear_waker() can't turn the None-check into a race.
+        waker = self._waker
+        if waker is not None:
+            try:
+                waker()
+            except Exception:
+                # A broken waker must never break request delivery. The
+                # request is already queued; a subsequent wake (or the
+                # processor's initial drain on restart) will pick it up,
+                # and the 30s timeout below bounds the worst case. Logged
+                # (not printed) so the diagnostic file log captures it —
+                # the symptom is "requests hang 30s", prime diagnostics.
+                logger.warning(
+                    "Waker raised — request %s stays queued",
+                    request.request_id,
+                    exc_info=True,
+                )
+
         try:
             # Block until main thread responds (with timeout to prevent indefinite hang)
             # 30 second timeout is generous - typical operations complete in milliseconds
@@ -229,21 +303,22 @@ class QueueBridge:
     def get_pending_request(self) -> Optional[ToolRequest]:
         """Non-blocking check for pending requests.
 
-        Called from main thread (QTimer callback) to check if there are any
-        pending tool requests. This method NEVER blocks - it returns immediately
-        with either a request or None.
+        Called from main thread (the drain callback scheduled by the waker)
+        to check if there are any pending tool requests. This method NEVER
+        blocks - it returns immediately with either a request or None.
 
         Returns:
             The next pending request if one exists, otherwise None.
 
         Thread Safety:
             Safe to call from any thread, but designed to be called from the
-            Qt main thread in a QTimer callback.
+            Qt main thread in the drain callback.
 
         Performance:
-            This method is called every 25ms by the QTimer. The non-blocking
-            behavior ensures the Qt event loop is never blocked, keeping the
-            UI responsive.
+            Called in a drain-until-empty loop each time the waker schedules
+            a drain — never on a timer, so an idle server costs nothing. The
+            non-blocking behavior ensures the Qt event loop is never blocked,
+            keeping the UI responsive.
         """
         try:
             return self.request_queue.get_nowait()

--- a/anki_mcp_server/request_processor.py
+++ b/anki_mcp_server/request_processor.py
@@ -1,151 +1,215 @@
 """Request processor that handles MCP tool requests on Qt main thread.
 
-This module provides the RequestProcessor class which polls the request queue
-using a QTimer and executes Anki operations safely on the main thread.
+This module provides the RequestProcessor class which drains the request
+queue and executes Anki operations safely on the main thread. Dispatch is
+event-driven: the background MCP server thread enqueues a request and
+immediately wakes the main thread via ``mw.taskman.run_on_main``, which
+schedules a drain callback onto the Qt event loop. There is no polling
+timer, so an idle server causes zero main-thread wakeups.
 
 Thread Safety:
-    - Runs exclusively on Qt main thread (via QTimer callback)
-    - Safe to access mw.col here since Qt main thread owns it
+    - The drain callback runs exclusively on the Qt main thread (guaranteed
+      by ``mw.taskman.run_on_main``)
+    - Safe to access mw.col there since the Qt main thread owns it
     - Never blocks - uses non-blocking queue.get_nowait() internally
 
 Architecture:
-    - QTimer fires every 25ms (same interval as AnkiConnect)
-    - Each tick drains ALL pending requests from the queue
-    - Executes each request via handler registry
-    - Sends response back via QueueBridge to unblock waiting background thread
+    - start() registers a waker on the QueueBridge and schedules one initial
+      drain (to pick up requests enqueued while stopped)
+    - QueueBridge.send_request() puts the request, then fires the waker,
+      which schedules _process_pending() onto the main thread
+    - Each drain consumes ALL pending requests, so N concurrent wakes
+      coalesce safely: the first drain does the work, the rest are cheap
+      no-ops on an empty queue
+    - stop() clears the waker and flips the _active flag so late callbacks
+      (already queued in Qt's event loop) return without touching the queue
 
 Performance:
-    - 25ms polling interval adds negligible latency (~imperceptible)
-    - Batch processing prevents queue buildup under load
-    - Non-blocking operation keeps UI responsive
+    - Zero idle churn (no wakeups while no client is talking)
+    - Dispatch latency is one Qt event-loop turn (effectively immediate,
+      vs. up to a full polling interval with the old timer approach)
+    - Batch draining prevents queue buildup under load
 """
 
-from aqt import mw
-from aqt.qt import QTimer
+from typing import Callable, Optional
 
 from .handler_registry import execute
 from .queue_bridge import QueueBridge, ToolRequest, ToolResponse
 
 
 class RequestProcessor:
-    """Processes MCP requests on Qt main thread using QTimer.
+    """Processes MCP requests on Qt main thread via event-driven dispatch.
 
     This class is the bridge between the async MCP server (running in a
     background thread) and Anki's collection API (which must be accessed
-    from the Qt main thread). It uses a QTimer to periodically poll the
-    request queue and execute pending operations.
+    from the Qt main thread). It registers a waker on the QueueBridge:
+    whenever the background thread enqueues a request, the waker schedules
+    a drain callback onto the main thread via ``mw.taskman.run_on_main``.
 
     The processor is designed to:
     1. Never block the Qt event loop (keeps UI responsive)
-    2. Process all pending requests in each tick (drains queue)
+    2. Process all pending requests in each drain (empties the queue)
     3. Safely access mw.col (we're on main thread)
     4. Handle errors gracefully (returns error response instead of crashing)
+    5. Cause zero main-thread wakeups while idle (no polling timer)
 
     Usage:
         >>> bridge = QueueBridge()
         >>> processor = RequestProcessor(bridge)
-        >>> processor.start()  # Start processing requests
+        >>> processor.start()  # Register waker, drain anything already queued
         >>> # Later, during shutdown:
         >>> processor.stop()
 
     Attributes:
         _bridge: Thread-safe communication bridge to background thread.
-        _timer: Qt timer that triggers request processing.
+        _schedule_on_main: Injectable "run this closure on the main thread"
+            function. None means "resolve mw.taskman.run_on_main lazily" —
+            the injection seam exists so unit tests can substitute a
+            synchronous fake without a running Anki instance.
+        _active: True between start() and stop(). Late drain callbacks
+            (delivered by Qt after stop()) check this flag and return
+            immediately, closing the shutdown race.
 
     Note:
-        This class MUST be instantiated on the Qt main thread (where mw is
-        available). The timer will run on the same thread where it's created.
+        With the default scheduler this class requires a running Anki
+        instance (mw must exist by the time the first wake fires), but the
+        aqt import is lazy so the module itself imports without Anki.
     """
 
-    def __init__(self, bridge: QueueBridge) -> None:
+    def __init__(
+        self,
+        bridge: QueueBridge,
+        schedule_on_main: Optional[Callable[[Callable[[], None]], None]] = None,
+    ) -> None:
         """Initialize request processor.
 
         Args:
             bridge: Queue bridge for thread-safe communication with the
                 background MCP server thread.
+            schedule_on_main: Function that schedules a zero-argument
+                closure onto the Qt main thread. Defaults to
+                ``mw.taskman.run_on_main`` (resolved lazily on each call).
+                Unit tests inject a synchronous fake here.
 
         Note:
-            The QTimer is created with mw as parent to ensure proper Qt
-            lifecycle management. This means this class cannot be instantiated
-            outside of Anki (mw must exist).
+            No Qt objects are created — the processor only needs a way to
+            schedule closures onto the main thread, which taskman provides.
         """
         self._bridge = bridge
-        self._timer = QTimer(mw)
-        self._timer.timeout.connect(self._process_pending)
+        self._schedule_on_main = schedule_on_main
+        self._active = False
 
-    def start(self, interval_ms: int = 25) -> None:
+    def start(self) -> None:
         """Start processing requests.
 
-        Starts the QTimer which will call _process_pending() every interval_ms
-        milliseconds. This begins the request processing loop.
-
-        Args:
-            interval_ms: Polling interval in milliseconds. Default is 25ms,
-                which is the same interval used by AnkiConnect and provides
-                imperceptible latency while keeping the UI responsive.
+        Registers the waker on the bridge so every subsequent
+        ``send_request()`` schedules a drain onto the main thread, then
+        schedules one initial drain to pick up any requests that were
+        enqueued while the processor was stopped (their wakes fired into
+        the void because no waker was registered).
 
         Note:
-            Calling start() when already started is safe - QTimer.start()
-            will restart the timer with the new interval.
-
-        Performance:
-            - 25ms = 40 Hz polling rate
-            - Typical Anki operations complete in < 5ms
-            - Total added latency: ~0-25ms (one timer interval)
-            - UI remains responsive (no blocking)
+            Idempotent — calling start() when already started is a no-op,
+            so the waker is never double-registered and no extra initial
+            drain is scheduled.
         """
-        self._timer.start(interval_ms)
+        if self._active:
+            return
+        self._active = True
+        self._bridge.set_waker(self._wake)
+        # Initial drain: requests enqueued while stopped had no waker to
+        # fire, so they are sitting in the queue with nobody scheduled to
+        # consume them. One explicit drain covers that window.
+        self._schedule(self._process_pending)
 
     def stop(self) -> None:
         """Stop processing requests.
 
-        Stops the QTimer, which stops calling _process_pending(). Any requests
-        currently in the queue will remain there until start() is called again.
+        Clears the waker on the bridge (new puts no longer schedule drains)
+        and flips the _active flag so any drain callback already queued in
+        Qt's event loop becomes a no-op when it eventually runs. Any
+        requests currently in the queue remain there until start() is
+        called again (whose initial drain picks them up).
 
         This should be called during addon shutdown to clean up resources.
 
         Note:
-            Calling stop() when already stopped is safe - QTimer.stop() is
-            idempotent.
+            Idempotent — calling stop() when already stopped (or never
+            started) is a no-op.
         """
-        self._timer.stop()
+        if not self._active:
+            return
+        self._active = False
+        self._bridge.clear_waker()
+
+    def _wake(self) -> None:
+        """Waker registered on the bridge.
+
+        Called from the background thread immediately after a request is
+        enqueued (see QueueBridge.send_request). Schedules a drain onto the
+        Qt main thread — ``run_on_main`` is thread-safe, so this is the
+        only cross-thread hop needed.
+        """
+        self._schedule(self._process_pending)
+
+    def _schedule(self, callback: Callable[[], None]) -> None:
+        """Schedule a closure onto the Qt main thread.
+
+        Uses the injected scheduler if one was provided, otherwise resolves
+        ``mw.taskman.run_on_main`` lazily. The lazy aqt import keeps this
+        module importable in environments without Anki (unit tests inject
+        their own scheduler and never hit this path).
+        """
+        schedule = self._schedule_on_main
+        if schedule is None:
+            from aqt import mw
+
+            schedule = mw.taskman.run_on_main
+        schedule(callback)
 
     def _process_pending(self) -> None:
         """Process all pending requests from the queue.
 
-        Called automatically by QTimer every interval_ms milliseconds. This
-        method:
-        1. Checks for pending requests (non-blocking)
-        2. If found, executes the tool via handler registry
-        3. Sends response back via bridge
-        4. Repeats until queue is empty
+        Runs on the Qt main thread, scheduled by the waker (or by start()'s
+        initial drain). This method:
+        1. Returns immediately if the processor has been stopped
+        2. Checks for pending requests (non-blocking)
+        3. If found, executes the tool via handler registry
+        4. Sends response back via bridge
+        5. Repeats until queue is empty
 
-        The loop structure ensures we drain the entire queue in one timer tick,
-        preventing request buildup under load.
+        The drain-until-empty loop is what makes concurrent wakes coalesce:
+        if N requests are enqueued before the first drain runs, that drain
+        consumes all N, and the remaining N-1 scheduled callbacks find an
+        empty queue and exit immediately.
 
         Thread Safety:
-            - Runs on Qt main thread (guaranteed by QTimer)
+            - Runs on Qt main thread (guaranteed by run_on_main)
             - Safe to access mw.col here
             - Non-blocking queue operations keep UI responsive
+
+        Shutdown Race:
+            Qt may deliver an already-queued callback after stop() — the
+            _active check at the top makes such late callbacks harmless
+            no-ops that never touch the queue.
 
         Error Handling:
             - Exceptions during tool execution are caught and returned as
               error responses
             - Processing continues even if one request fails
-            - Never crashes the timer or Anki
-
-        Performance:
-            - Processes requests until queue is empty
-            - Typical queue depth: 0-2 requests
-            - Each iteration takes ~1-10ms depending on operation
-            - Total time per tick rarely exceeds the 25ms interval
+            - Never crashes the Qt event loop or Anki
         """
+        if not self._active:
+            # Late callback delivered after stop() — teardown may already be
+            # underway, so don't touch the queue or execute anything.
+            return
+
         while True:
             # Non-blocking check for pending request
             # Returns None immediately if queue is empty
             request = self._bridge.get_pending_request()
             if request is None:
-                break  # Queue empty, exit until next timer tick
+                break  # Queue empty, exit until the next wake
 
             # Execute the tool and get response (success or error)
             response = self._execute_tool(request)
@@ -170,7 +234,7 @@ class RequestProcessor:
 
         Error Handling:
             - All exceptions are caught and converted to error responses
-            - This prevents exceptions from propagating to the timer
+            - This prevents exceptions from propagating to the Qt event loop
             - Exception message is returned to the MCP client
 
         Example:

--- a/tests/unit/test_request_processor.py
+++ b/tests/unit/test_request_processor.py
@@ -1,0 +1,433 @@
+"""Unit tests for RequestProcessor event-driven dispatch.
+
+Tests the waker/drain mechanics directly, without Anki or Docker: a real
+QueueBridge plus an injected fake ``schedule_on_main`` replace the
+``mw.taskman.run_on_main`` path. The handler registry's ``execute`` is
+monkeypatched (real handlers touch mw.col).
+
+Two fake schedulers drive the tests:
+- ImmediateScheduler runs the drain closure synchronously inside the waker,
+  i.e. inline within send_request()'s calling thread BEFORE it blocks — so
+  the response is already queued when send_request() gets to its get().
+- DeferredScheduler collects closures for manual invocation, which lets
+  tests observe coalescing (one drain handles a burst) and the
+  stop-then-late-callback shutdown race.
+
+One test exercises the DEFAULT scheduler path instead of injecting: a fake
+``mw`` installed on the stubbed ``aqt`` module (conftest's ``install_mw``)
+proves the lazy ``mw.taskman.run_on_main`` resolution actually works.
+"""
+
+import threading
+import time
+import types
+
+import pytest
+
+from anki_mcp_server.queue_bridge import QueueBridge, ToolRequest, ToolResponse
+from anki_mcp_server.request_processor import RequestProcessor
+
+
+class ImmediateScheduler:
+    """Fake schedule_on_main that runs the closure synchronously."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, closure) -> None:
+        self.calls += 1
+        closure()
+
+
+class DeferredScheduler:
+    """Fake schedule_on_main that collects closures for manual invocation."""
+
+    def __init__(self) -> None:
+        self.closures: list = []
+        self._lock = threading.Lock()
+
+    def __call__(self, closure) -> None:
+        with self._lock:
+            self.closures.append(closure)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self.closures)
+
+
+def _make_request(request_id: str, tool_name: str = "test") -> ToolRequest:
+    return ToolRequest(request_id=request_id, tool_name=tool_name, arguments={})
+
+
+@pytest.fixture()
+def fake_execute(monkeypatch):
+    """Stub the handler registry: echo the tool name, record calls."""
+    calls: list[str] = []
+
+    def _execute(tool_name, arguments):
+        calls.append(tool_name)
+        return f"result:{tool_name}"
+
+    monkeypatch.setattr("anki_mcp_server.request_processor.execute", _execute)
+    return calls
+
+
+class TestActiveDispatch:
+    """Requests enqueued while active are dispatched immediately."""
+
+    def test_request_dispatched_via_waker(self, fake_execute):
+        """put -> wake -> drain -> response, all inline with a sync scheduler.
+
+        With ImmediateScheduler the waker runs the drain synchronously inside
+        send_request()'s calling thread, before it blocks — so the response
+        is already in the per-request queue when get() runs and send_request
+        returns without ever waiting.
+        """
+        bridge = QueueBridge()
+        scheduler = ImmediateScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+        processor.start()
+
+        response = bridge.send_request(_make_request("r1", "list_decks"))
+
+        assert response.success is True
+        assert response.request_id == "r1"
+        assert response.result == "result:list_decks"
+        assert fake_execute == ["list_decks"]
+
+    def test_multiple_sequential_requests(self, fake_execute):
+        bridge = QueueBridge()
+        processor = RequestProcessor(bridge, schedule_on_main=ImmediateScheduler())
+        processor.start()
+
+        for i in range(3):
+            response = bridge.send_request(_make_request(f"r{i}", f"tool_{i}"))
+            assert response.success is True
+            assert response.result == f"result:tool_{i}"
+
+        assert fake_execute == ["tool_0", "tool_1", "tool_2"]
+
+    def test_handler_exception_returns_error_response(self, monkeypatch):
+        def _boom(tool_name, arguments):
+            raise ValueError("handler exploded")
+
+        monkeypatch.setattr("anki_mcp_server.request_processor.execute", _boom)
+
+        bridge = QueueBridge()
+        processor = RequestProcessor(bridge, schedule_on_main=ImmediateScheduler())
+        processor.start()
+
+        response = bridge.send_request(_make_request("r1"))
+
+        assert response.success is False
+        assert "handler exploded" in response.error
+
+
+class TestBurstCoalescing:
+    """N wakes before any drain runs: one drain does all the work."""
+
+    def test_one_drain_handles_burst_and_rest_are_noops(self, fake_execute):
+        bridge = QueueBridge()
+        scheduler = DeferredScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+        processor.start()
+        assert len(scheduler) == 1  # initial drain scheduled by start()
+
+        num_requests = 5
+        results: dict[str, ToolResponse] = {}
+        lock = threading.Lock()
+
+        def sender(rid: str, tool: str):
+            resp = bridge.send_request(_make_request(rid, tool))
+            with lock:
+                results[rid] = resp
+
+        threads = [
+            threading.Thread(target=sender, args=(f"r{i}", f"tool_{i}"))
+            for i in range(num_requests)
+        ]
+        for t in threads:
+            t.start()
+
+        # Wait until every sender has enqueued + fired its wake.
+        for _ in range(1000):
+            if len(scheduler) == 1 + num_requests:
+                break
+            time.sleep(0.005)
+        assert len(scheduler) == 1 + num_requests
+
+        # ONE collected closure drains all N requests.
+        scheduler.closures[1]()
+        for t in threads:
+            t.join(timeout=10)
+        assert all(not t.is_alive() for t in threads)
+
+        assert len(results) == num_requests
+        for i in range(num_requests):
+            assert results[f"r{i}"].success is True
+            assert results[f"r{i}"].result == f"result:tool_{i}"
+        assert sorted(fake_execute) == sorted(f"tool_{i}" for i in range(num_requests))
+
+        # The remaining collected closures find an empty queue: cheap no-ops.
+        for closure in scheduler.closures:
+            closure()
+        assert len(fake_execute) == num_requests  # nothing executed twice
+
+
+class TestShutdownRace:
+    """Late drain callbacks after stop() must be harmless no-ops."""
+
+    def test_late_callback_after_stop_does_not_touch_queue(self, fake_execute):
+        bridge = QueueBridge()
+        scheduler = DeferredScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+        processor.start()
+        late_drain = scheduler.closures[0]
+
+        processor.stop()
+
+        # A request sitting in the queue (enqueued directly to avoid blocking
+        # on send_request — no consumer is active).
+        bridge.request_queue.put(_make_request("r1", "orphan"))
+
+        # Qt delivering an already-queued callback after stop(): no crash,
+        # no execution, request stays queued.
+        late_drain()
+
+        assert fake_execute == []
+        pending = bridge.get_pending_request()
+        assert pending is not None
+        assert pending.request_id == "r1"
+
+
+class TestStartStopIdempotence:
+    """start()/stop() are safe to call twice, in any order."""
+
+    def test_double_start_registers_waker_once(self, fake_execute):
+        bridge = QueueBridge()
+        scheduler = DeferredScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+
+        processor.start()
+        processor.start()
+
+        # Second start is a no-op: exactly one initial drain, one waker.
+        assert len(scheduler) == 1
+        assert bridge._waker is not None
+
+    def test_double_stop_is_safe(self):
+        bridge = QueueBridge()
+        processor = RequestProcessor(bridge, schedule_on_main=DeferredScheduler())
+        processor.start()
+
+        processor.stop()
+        processor.stop()
+
+        assert bridge._waker is None
+
+    def test_stop_before_start_is_safe(self):
+        bridge = QueueBridge()
+        processor = RequestProcessor(bridge, schedule_on_main=DeferredScheduler())
+
+        processor.stop()  # never started — must not crash
+
+        assert bridge._waker is None
+
+    def test_initial_drain_picks_up_requests_enqueued_while_stopped(
+        self, fake_execute
+    ):
+        """Requests enqueued with no waker registered are drained by start()."""
+        bridge = QueueBridge()
+        result_holder: list[ToolResponse] = []
+
+        def sender():
+            result_holder.append(bridge.send_request(_make_request("r1", "early")))
+
+        # No processor running: send_request enqueues, wakes nobody, blocks.
+        t = threading.Thread(target=sender)
+        t.start()
+        for _ in range(1000):
+            if not bridge.request_queue.empty():
+                break
+            time.sleep(0.005)
+        assert not bridge.request_queue.empty()
+
+        # start() with a synchronous scheduler runs the initial drain inline.
+        processor = RequestProcessor(bridge, schedule_on_main=ImmediateScheduler())
+        processor.start()
+
+        t.join(timeout=10)
+        assert not t.is_alive()
+        assert len(result_holder) == 1
+        assert result_holder[0].success is True
+        assert result_holder[0].result == "result:early"
+
+
+class TestRestart:
+    """stop() -> start() on the SAME instance must fully re-arm dispatch."""
+
+    def test_stop_then_start_reregisters_waker_and_drains(self, fake_execute):
+        """Restart re-registers the waker, schedules a fresh initial drain,
+        and picks up a request enqueued while stopped.
+
+        Guards against a future refactor making start() one-shot (e.g. an
+        "already initialized" early-return that skips waker registration or
+        the initial drain on the second start).
+        """
+        bridge = QueueBridge()
+        scheduler = DeferredScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+        processor.start()
+        assert len(scheduler) == 1  # initial drain from the first start()
+
+        processor.stop()
+
+        # Enqueue while stopped: send_request blocks (no consumer), so run
+        # it on a thread. Its wake fires into the void — no waker registered.
+        results: list[ToolResponse] = []
+
+        def sender(rid: str, tool: str):
+            results.append(bridge.send_request(_make_request(rid, tool)))
+
+        t1 = threading.Thread(target=sender, args=("r1", "while_stopped"))
+        t1.start()
+        for _ in range(1000):
+            if not bridge.request_queue.empty():
+                break
+            time.sleep(0.005)
+        assert not bridge.request_queue.empty()
+        assert len(scheduler) == 1  # nothing was scheduled while stopped
+
+        processor.start()  # restart on the SAME instance
+
+        # Restart re-registered the waker and scheduled a NEW initial drain.
+        assert bridge._waker is not None
+        assert len(scheduler) == 2
+        scheduler.closures[1]()  # run the fresh initial drain
+
+        t1.join(timeout=10)
+        assert not t1.is_alive()
+        assert results[0].success is True
+        assert results[0].result == "result:while_stopped"
+
+        # Post-restart dispatch: a new request fires the re-registered
+        # waker (observable as a third scheduled closure).
+        t2 = threading.Thread(target=sender, args=("r2", "after_restart"))
+        t2.start()
+        for _ in range(1000):
+            if len(scheduler) == 3:
+                break
+            time.sleep(0.005)
+        assert len(scheduler) == 3
+        scheduler.closures[2]()
+
+        t2.join(timeout=10)
+        assert not t2.is_alive()
+        assert results[1].success is True
+        assert results[1].result == "result:after_restart"
+
+
+class TestDefaultLazyScheduler:
+    """Default scheduler path: lazily resolved ``mw.taskman.run_on_main``."""
+
+    def test_dispatch_via_lazily_resolved_mw_taskman(
+        self, fake_execute, install_mw
+    ):
+        """No injected scheduler: _schedule resolves mw.taskman.run_on_main.
+
+        A fake ``mw`` (installed on the stubbed aqt module via conftest's
+        ``install_mw``) exposes a synchronous ``taskman.run_on_main`` that
+        counts calls — proving both the attribute path (a typo in the
+        attribute name would AttributeError here instead of only surfacing
+        inside Anki) and that start() + dispatch actually flow through it.
+        """
+        run_on_main = ImmediateScheduler()
+        install_mw(
+            types.SimpleNamespace(
+                taskman=types.SimpleNamespace(run_on_main=run_on_main)
+            )
+        )
+
+        bridge = QueueBridge()
+        processor = RequestProcessor(bridge)  # default: lazy mw resolution
+        processor.start()
+        assert run_on_main.calls == 1  # initial drain went through taskman
+
+        response = bridge.send_request(_make_request("r1", "list_decks"))
+
+        assert response.success is True
+        assert response.result == "result:list_decks"
+        assert run_on_main.calls == 2  # the wake also went through taskman
+        assert fake_execute == ["list_decks"]
+
+
+class TestWakerExceptionSafety:
+    """A raising waker must never break send_request delivery."""
+
+    def test_send_request_survives_raising_waker(self):
+        bridge = QueueBridge()
+        bridge.set_waker(lambda: (_ for _ in ()).throw(RuntimeError("waker broke")))
+
+        result_holder: list[ToolResponse] = []
+        error_holder: list[Exception] = []
+
+        def sender():
+            try:
+                result_holder.append(bridge.send_request(_make_request("r1", "tool")))
+            except Exception as e:  # noqa: BLE001
+                error_holder.append(e)
+
+        t = threading.Thread(target=sender)
+        t.start()
+
+        # The waker raised, but the request must still be queued; drain it
+        # manually and respond.
+        for _ in range(1000):
+            request = bridge.get_pending_request()
+            if request is not None:
+                break
+            time.sleep(0.005)
+        assert request is not None
+        bridge.send_response(
+            ToolResponse(request_id=request.request_id, success=True, result="ok")
+        )
+
+        t.join(timeout=10)
+        assert not t.is_alive()
+        assert error_holder == []  # waker exception never propagated
+        assert len(result_holder) == 1
+        assert result_holder[0].success is True
+        assert result_holder[0].result == "ok"
+
+    def test_raising_waker_with_processor_drain(self, fake_execute, monkeypatch):
+        """End-to-end: waker raises, a manual drain still delivers."""
+        bridge = QueueBridge()
+        scheduler = DeferredScheduler()
+        processor = RequestProcessor(bridge, schedule_on_main=scheduler)
+        processor.start()
+
+        # Sabotage the registered waker AFTER start() wired it up.
+        bridge.set_waker(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        result_holder: list[ToolResponse] = []
+
+        def sender():
+            result_holder.append(bridge.send_request(_make_request("r1", "tool_x")))
+
+        t = threading.Thread(target=sender)
+        t.start()
+        for _ in range(1000):
+            if not bridge.request_queue.empty():
+                break
+            time.sleep(0.005)
+
+        # No new drain was scheduled (the waker raised) — the initial drain
+        # from start() stands in for "a subsequent wake picks it up".
+        assert len(scheduler) == 1
+        scheduler.closures[0]()
+
+        t.join(timeout=10)
+        assert not t.is_alive()
+        assert len(result_holder) == 1
+        assert result_holder[0].success is True
+        assert result_holder[0].result == "result:tool_x"


### PR DESCRIPTION
Replaces the RequestProcessor's 40Hz polling QTimer with event-driven dispatch onto the Qt main thread.

- `QueueBridge.send_request()` invokes an injected waker after enqueue (put → wake → block); waker is snapshot-then-call outside locks and exception-safe. Bridge stays stdlib-only.
- `RequestProcessor` schedules its drain-until-empty `_process_pending` via `mw.taskman.run_on_main`; `start()` registers the waker + one initial drain, `stop()` + `_active` guard make late Qt-queued callbacks no-ops.
- Removes all idle wakeups (40/s → 0) and improves latency (immediate dispatch vs 0–25ms tick wait). No fallback timer: the 30s send_request timeout plus `shutdown()`'s pending-queue flush cover the only lost-wake window.
- New unit suite: immediate dispatch, burst coalescing, stop/late-callback race, start/stop idempotence, restart, waker-exception safety, default scheduler path.

Verified: 417 unit tests, full E2E (regular + filtered) green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)