### PR TITLE
Treat tunnel IDLE_TIMEOUT (4010) close code as permanent, no reconnect

### DIFF
--- a/anki_mcp_server/__init__.py
+++ b/anki_mcp_server/__init__.py
@@ -17,7 +17,7 @@ if sys.version_info < (3, 10):
 
 from pathlib import Path
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 # Packages we vendor directly (we ship our own copy under vendor/shared). This
 # is the set used for the system-package FALLBACK check on source/Nix installs:

--- a/anki_mcp_server/tunnel/protocol.py
+++ b/anki_mcp_server/tunnel/protocol.py
@@ -35,6 +35,7 @@ class CloseCodes:
     URL_REGENERATED = 4006
     SERVICE_UNAVAILABLE = 4008
     SHUTDOWN = 4009
+    IDLE_TIMEOUT = 4010
 
 
 # Close codes that mean "don't bother reconnecting"
@@ -43,6 +44,7 @@ _NO_RECONNECT: set[int] = {
     CloseCodes.TOKEN_REVOKED,
     CloseCodes.ACCOUNT_DELETED,
     CloseCodes.SESSION_REPLACED,
+    CloseCodes.IDLE_TIMEOUT,
 }
 
 # Close codes that mean "get a fresh token before reconnecting"

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             pname = "anki-mcp-server";
             # Must match __version__ in anki_mcp_server/__init__.py, which is the
             # single source of truth. Enforced by tests/unit/test_version_consistency.py.
-            version = "0.27.0";
+            version = "0.28.0";
             src = ./anki_mcp_server;
 
             postFixup = ''


### PR DESCRIPTION
Free-tier tunnels are disconnected by the relay after 12h of inactivity; the addon should stop reconnecting rather than retry a connection the server intends to stay closed, same as SESSION_REPLACED.